### PR TITLE
Update Dataset:DatasetCase relationship

### DIFF
--- a/application/backend/src/api/routes/dataset-routes.ts
+++ b/application/backend/src/api/routes/dataset-routes.ts
@@ -84,7 +84,7 @@ export const datasetRoutes = async (fastify: FastifyInstance, opts: any) => {
       const keyPrefix = body.keyPrefix;
 
       agService.syncDbFromS3KeyPrefix(keyPrefix);
-      reply.send("ok");
+      reply.send("OK! \nTo prevent API timeout, returning the OK value while the script is still running. ");
     }
   );
 };

--- a/application/backend/src/api/routes/dataset-routes.ts
+++ b/application/backend/src/api/routes/dataset-routes.ts
@@ -76,16 +76,6 @@ export const datasetRoutes = async (fastify: FastifyInstance, opts: any) => {
     });
   });
 
-  /**
-   * Before triggering this endpoint. There are pre-requisite to be able to record the data.
-   * A dataset with a single datasetCase must exist with the correct dataset uri.
-   * Enter the following for edgeDb cli
-   * insert dataset::Dataset{
-   *   description:="New Cardaic",
-   *   cases:= (insert dataset::DatasetCase{}),
-   *   uri:= "urn:fdc:australiangenomics.org.au:2022:datasets/cardiac"
-   * };
-   */
   fastify.post<{ Body: { keyPrefix: string } }>(
     "/api/datasets/ag/import",
     {},

--- a/application/backend/src/business/db/lab-queries.ts
+++ b/application/backend/src/business/db/lab-queries.ts
@@ -58,20 +58,11 @@ export function insertArtifactCramQuery(cramFile: File, craiFile: File) {
 /**
  * SELECT function queries
  */
-export const fastqArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
-  { datasetCaseId: e.uuid },
+export const fastqArtifactStudyIdAndFileIdByDatasetIdQuery = e.params(
+  { datasetId: e.uuid },
   (params) =>
     e.select(e.lab.ArtifactFastqPair, (fastqArtifact) => {
-      // const vcfForwardFileQuery = e.select(e.storage.File, (file) => ({
-      //   url: true,
-      //   filter: e.op(file.id, "=", fastqArtifact.forwardFile.id),
-      // }));
-      // const vcfReverseFileQuery = e.select(e.storage.File, (file) => ({
-      //   url: true,
-      //   filter: e.op(file.id, "=", fastqArtifact.reverseFile.id),
-      // }));
       return {
-        // fileId: e.set(vcfForwardFileQuery, vcfReverseFileQuery),
         fileIdList: e.set(
           fastqArtifact.forwardFile.id,
           fastqArtifact.reverseFile.id
@@ -80,16 +71,16 @@ export const fastqArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
           fastqArtifact["<artifacts[is dataset::DatasetSpecimen]"].patient
             .externalIdentifiers,
         filter: e.op(
-          fastqArtifact["<artifacts[is dataset::DatasetSpecimen]"].case_.id,
+          fastqArtifact["<artifacts[is dataset::DatasetSpecimen]"].dataset.id,
           "=",
-          params.datasetCaseId
+          params.datasetId
         ),
       };
     })
 );
 
-export const bamArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
-  { datasetCaseId: e.uuid },
+export const bamArtifactStudyIdAndFileIdByDatasetIdQuery = e.params(
+  { datasetId: e.uuid },
   (params) =>
     e.select(e.lab.ArtifactBam, (bamArtifact) => {
       return {
@@ -98,16 +89,16 @@ export const bamArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
           bamArtifact["<artifacts[is dataset::DatasetSpecimen]"].patient
             .externalIdentifiers,
         filter: e.op(
-          bamArtifact["<artifacts[is dataset::DatasetSpecimen]"].case_.id,
+          bamArtifact["<artifacts[is dataset::DatasetSpecimen]"].dataset.id,
           "=",
-          params.datasetCaseId
+          params.datasetId
         ),
       };
     })
 );
 
-export const cramArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
-  { datasetCaseId: e.uuid },
+export const cramArtifactStudyIdAndFileIdByDatasetIdQuery = e.params(
+  { datasetId: e.uuid },
   (params) =>
     e.select(e.lab.ArtifactCram, (cramArtifact) => {
       return {
@@ -116,16 +107,16 @@ export const cramArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
           cramArtifact["<artifacts[is dataset::DatasetSpecimen]"].patient
             .externalIdentifiers,
         filter: e.op(
-          cramArtifact["<artifacts[is dataset::DatasetSpecimen]"].case_.id,
+          cramArtifact["<artifacts[is dataset::DatasetSpecimen]"].dataset.id,
           "=",
-          params.datasetCaseId
+          params.datasetId
         ),
       };
     })
 );
 
-export const vcfArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
-  { datasetCaseId: e.uuid },
+export const vcfArtifactStudyIdAndFileIdByDatasetIdQuery = e.params(
+  { datasetId: e.uuid },
   (params) =>
     e.select(e.lab.ArtifactVcf, (vcfArtifact) => {
       return {
@@ -134,9 +125,9 @@ export const vcfArtifactStudyIdAndFileIdByDatasetCaseIdQuery = e.params(
           vcfArtifact["<artifacts[is dataset::DatasetSpecimen]"].patient
             .externalIdentifiers,
         filter: e.op(
-          vcfArtifact["<artifacts[is dataset::DatasetSpecimen]"].case_.id,
+          vcfArtifact["<artifacts[is dataset::DatasetSpecimen]"].dataset.id,
           "=",
-          params.datasetCaseId
+          params.datasetId
         ),
       };
     })

--- a/application/backend/src/business/services/ag-service.ts
+++ b/application/backend/src/business/services/ag-service.ts
@@ -565,7 +565,7 @@ export class AGService {
     const datasetId = await this.getDatasetIdByS3KeyPrefix(s3KeyPrefix);
     if (!datasetId) {
       console.warn("No Dataset URI found from given key prefix.");
-      console.warn("Please register the key prefix before running it though this function.");
+      console.warn("Please register the key prefix before running it through this function.");
       return;
     }
 

--- a/application/backend/src/business/services/ag-service.ts
+++ b/application/backend/src/business/services/ag-service.ts
@@ -488,7 +488,7 @@ export class AGService {
         });
 
         if (!file) {
-          continue; // Should not going here
+          continue; // Should not go here
         }
 
         s3UrlManifestObj[file.url] = {

--- a/application/backend/src/business/services/ag-service.ts
+++ b/application/backend/src/business/services/ag-service.ts
@@ -564,8 +564,8 @@ export class AGService {
   async syncDbFromS3KeyPrefix(s3KeyPrefix: string) {
     const datasetId = await this.getDatasetIdByS3KeyPrefix(s3KeyPrefix);
     if (!datasetId) {
-      console.log("No DataCase found for this prefix.");
-      console.log("Please insert a new datacase before running this function");
+      console.warn("No Dataset URI found from given key prefix.");
+      console.warn("Please register the key prefix before running it though this function.");
       return;
     }
 

--- a/application/backend/src/business/services/ag-service.ts
+++ b/application/backend/src/business/services/ag-service.ts
@@ -121,9 +121,9 @@ export class AGService {
     const headers = lines[0].split("\t");
     for (let i = 1; i < lines.length; i++) {
       const obj: Record<string, string> = {};
-      const currentline = lines[i].split("\t");
+      const currentLine = lines[i].split("\t");
       for (let j = 0; j < headers.length; j++) {
-        obj[headers[j]] = currentline[j];
+        obj[headers[j]] = currentLine[j];
       }
       result.push(obj);
     }
@@ -176,7 +176,7 @@ export class AGService {
         this.convertTsvToJson(manifestTsvContent)
       );
 
-      // The manifest will contain a filename only, but for the purpose of uniquness and how we stored in db.
+      // The manifest will contain a filename only, but for the purpose of uniqueness and how we stored in db.
       // We would append the filename with the s3 Url prefix.
       for (const manifestObj of manifestObjContentList) {
         const s3Url = `${s3UrlPrefix}/${manifestObj.filename}`;
@@ -192,7 +192,7 @@ export class AGService {
 
   /**
    * To group file in their artifact type and filename.
-   * The function will determine artifacttype by
+   * The function will determine artifact type by
    * @param fileRecordListedInManifest
    * @returns A nested json of artifactType AND filenameId
    * E.g. From {FASTQ : { A00001 : [File1, File2] } }
@@ -373,7 +373,7 @@ export class AGService {
     datasetPatientId: string,
     insertArtifactListQuery: any
   ) {
-    const updateDatapatientQuery = e.update(
+    const updateDataPatientQuery = e.update(
       e.dataset.DatasetSpecimen,
       (specimen) => ({
         set: {
@@ -384,7 +384,7 @@ export class AGService {
         filter: e.op(specimen.patient.id, "=", e.uuid(datasetPatientId)),
       })
     );
-    await updateDatapatientQuery.run(this.edgeDbClient);
+    await updateDataPatientQuery.run(this.edgeDbClient);
   }
 
   async getDatasetPatientByStudyId(studyId: string) {
@@ -402,13 +402,13 @@ export class AGService {
   }
 
   /**
-   * Inserting artifacts query to appropriate datacase
+   * Inserting artifacts query to appropriate dataset
    * @param datasetId
    * @param studyId
    * @param insertArtifactListQuery
    * @returns
    */
-  async insertNewDatsetPatientByDatasetId(
+  async insertNewDatasetPatientByDatasetId(
     datasetId: string,
     studyId: string,
     insertArtifactListQuery: any
@@ -509,7 +509,7 @@ export class AGService {
    * @param manifestBeta
    * @returns
    */
-  diffManifestAplhaAndManifestBeta(
+  diffManifestAlphaAndManifestBeta(
     manifestAlpha: manifestDict,
     manifestBeta: manifestDict
   ): s3ManifestType[] {
@@ -579,12 +579,12 @@ export class AGService {
     // Grab all s3ManifestType object from current edgedb
     const dbs3ManifestTypeObjectDict =
       await this.getDbManifestObjectListByDatasetId(datasetId);
-    // Do comparison for data retreive from s3 and with current edgedb data
-    const missingFileFromDb = this.diffManifestAplhaAndManifestBeta(
+    // Do comparison for data retrieve from s3 and with current edgedb data
+    const missingFileFromDb = this.diffManifestAlphaAndManifestBeta(
       s3ManifestTypeObjectDict,
       dbs3ManifestTypeObjectDict
     );
-    const toBeDeletedFromDb = this.diffManifestAplhaAndManifestBeta(
+    const toBeDeletedFromDb = this.diffManifestAlphaAndManifestBeta(
       dbs3ManifestTypeObjectDict,
       s3ManifestTypeObjectDict
     );
@@ -643,7 +643,7 @@ export class AGService {
           );
         } else {
           // Insert New DatasetPatient
-          await this.insertNewDatsetPatientByDatasetId(
+          await this.insertNewDatasetPatientByDatasetId(
             datasetId,
             studyId,
             insertArtifactListQuery

--- a/application/backend/src/test-data/insert-test-data.ts
+++ b/application/backend/src/test-data/insert-test-data.ts
@@ -26,7 +26,7 @@ export async function insertTestData(settings: ElsaSettings) {
   await insert10G();
   await insert10F();
   await insert10C();
-  await insertCARDIAC();
+  // await insertCARDIAC();
 
   await insertBlankDataset(
     "BM",

--- a/application/backend/tests/service-tests/ag.common.ts
+++ b/application/backend/tests/service-tests/ag.common.ts
@@ -6,6 +6,7 @@ import e, { storage } from "../../dbschema/edgeql-js";
 
 export const MOCK_DATASET_URI =
   "urn:fdc:australiangenomics.org.au:2022:datasets/cardiac";
+export const S3_URL_PREFIX = "s3://agha-gdr-store-2.0/Cardiac/2019-11-21";
 
 function createS3ObjectList(key = "S3_KEY", etag = "AWS_ETAG", size = 1) {
   return {
@@ -28,7 +29,7 @@ function createManifestObject(
 }
 
 function createS3UrlManifestObject(
-  s3Url = "s3://agha-gdr-store-2.0/Cardiac/2019-11-21/FILE_L001_R1.fastq.gz",
+  s3Url = `${S3_URL_PREFIX}/FILE_L001_R1.fastq.gz`,
   agha_study_id = "A0000001",
   checksum = "RANDOMCHECKSUM"
 ) {
@@ -81,10 +82,10 @@ export const MOCK_1_MANIFEST_OBJECT = [
 
 export const MOCK_1_S3URL_MANIFEST_OBJECT = [
   createS3UrlManifestObject(
-    `s3://agha-gdr-store-2.0/Cardiac/2019-11-21/${MOCK_1_CARDIAC_FASTQ1_FILENAME}`
+    `${S3_URL_PREFIX}/${MOCK_1_CARDIAC_FASTQ1_FILENAME}`
   ),
   createS3UrlManifestObject(
-    `s3://agha-gdr-store-2.0/Cardiac/2019-11-21/${MOCK_1_CARDIAC_FASTQ2_FILENAME}`
+    `${S3_URL_PREFIX}/${MOCK_1_CARDIAC_FASTQ2_FILENAME}`
   ),
 ];
 
@@ -150,11 +151,11 @@ export const MOCK_3_CARDIAC_MANIFEST = `checksum\tfilename\tagha_study_id\n`;
 
 export const MOCK_FASTQ_FORWARD_FILE_RECORD = {
   ...MOCK_FILE_RECORD_TEMPLATE,
-  url: "s3://agha-gdr-store-2.0/Cardiac/2019-11-21/FILE_L001_R1.fastq.gz",
+  url: `${S3_URL_PREFIX}/FILE_L001_R1.fastq.gz`,
 };
 export const MOCK_FASTQ_REVERSE_FILE_RECORD = {
   ...MOCK_FILE_RECORD_TEMPLATE,
-  url: "s3://agha-gdr-store-2.0/Cardiac/2019-11-21/FILE_L001_R2.fastq.gz",
+  url: `${S3_URL_PREFIX}/FILE_L001_R2.fastq.gz`,
 };
 
 export const MOCK_FASTQ_PAIR_FILE_SET = [
@@ -164,22 +165,22 @@ export const MOCK_FASTQ_PAIR_FILE_SET = [
 
 export const MOCK_BAM_FILE_RECORD = {
   ...MOCK_FILE_RECORD_TEMPLATE,
-  url: "s3://agha-gdr-store-2.0/Cardiac/2019-11-21/A0000001.bam",
+  url: `${S3_URL_PREFIX}/A0000001.bam`,
 };
 export const MOCK_BAI_FILE_RECORD = {
   ...MOCK_FILE_RECORD_TEMPLATE,
-  url: "s3://agha-gdr-store-2.0/Cardiac/2019-11-21/A0000001.bam.bai",
+  url: `${S3_URL_PREFIX}/A0000001.bam.bai`,
 };
 
 export const MOCK_BAM_FILE_SET = [MOCK_BAM_FILE_RECORD, MOCK_BAI_FILE_RECORD];
 
 export const MOCK_VCF_FILE_RECORD = {
   ...MOCK_FILE_RECORD_TEMPLATE,
-  url: "s3://agha-gdr-store-2.0/Cardiac/2020-01-22/19W001062.individual.norm.vcf.gz",
+  url: `${S3_URL_PREFIX}/19W001062.individual.norm.vcf.gz`,
 };
 export const MOCK_TBI_FILE_RECORD = {
   ...MOCK_FILE_RECORD_TEMPLATE,
-  url: "s3://agha-gdr-store-2.0/Cardiac/2020-01-22/19W001062.individual.norm.vcf.gz.tbi",
+  url: `${S3_URL_PREFIX}/19W001062.individual.norm.vcf.gz.tbi`,
 };
 
 export const MOCK_VCF_FILE_SET = [MOCK_VCF_FILE_RECORD, MOCK_TBI_FILE_RECORD];

--- a/application/backend/tests/service-tests/ag.test.ts
+++ b/application/backend/tests/service-tests/ag.test.ts
@@ -30,6 +30,7 @@ import {
   MOCK_2_BAI_FILE_RECORD,
   MOCK_3_CARDIAC_S3_OBJECT_LIST,
   MOCK_3_CARDIAC_MANIFEST,
+  S3_URL_PREFIX,
 } from "./ag.common";
 import * as awsHelper from "../../src/business/services/aws-helper";
 import {
@@ -106,14 +107,19 @@ describe("AWS s3 client", () => {
       agService.groupManifestFileByArtifactTypeAndFilename(
         fileRecordListedInManifest
       );
-    expect(groupArtifactContent[ArtifactType.FASTQ]["FILE_L001"]).toEqual(
-      MOCK_FASTQ_PAIR_FILE_SET
-    );
-    expect(groupArtifactContent[ArtifactType.BAM]["A0000001.bam"]).toEqual(
-      MOCK_BAM_FILE_SET
-    );
+
     expect(
-      groupArtifactContent[ArtifactType.VCF]["19W001062.individual.norm.vcf"]
+      groupArtifactContent[ArtifactType.FASTQ][
+        `${S3_URL_PREFIX}/FILE_L001.fastq`
+      ]
+    ).toEqual(MOCK_FASTQ_PAIR_FILE_SET);
+    expect(
+      groupArtifactContent[ArtifactType.BAM][`${S3_URL_PREFIX}/A0000001.bam`]
+    ).toEqual(MOCK_BAM_FILE_SET);
+    expect(
+      groupArtifactContent[ArtifactType.VCF][
+        `${S3_URL_PREFIX}/19W001062.individual.norm.vcf`
+      ]
     ).toEqual(MOCK_VCF_FILE_SET);
   });
 
@@ -245,10 +251,10 @@ describe("AWS s3 client", () => {
     expect(totalFileList.length).toEqual(2);
     const expected = [
       {
-        url: `s3://agha-gdr-store-2.0/Cardiac/2019-11-21/${MOCK_1_CARDIAC_FASTQ1_FILENAME}`,
+        url: `${S3_URL_PREFIX}/${MOCK_1_CARDIAC_FASTQ1_FILENAME}`,
       },
       {
-        url: `s3://agha-gdr-store-2.0/Cardiac/2019-11-21/${MOCK_1_CARDIAC_FASTQ2_FILENAME}`,
+        url: `${S3_URL_PREFIX}/${MOCK_1_CARDIAC_FASTQ2_FILENAME}`,
       },
     ];
     expect(totalFileList).toEqual(expect.arrayContaining(expected));


### PR DESCRIPTION
- Record linking update: 
	- Each DatasetPatient is 1:1 DatasetCase
	- Each Dataset is 1:* DatasetCase
- Pre-insert of dataset is no longer required. (If given URI does not exist, it will insert a new Dataset record).
- Mapping of key-prefix is moved out to a constant on top of file (instead of being an if-else approach inside the  code)..
- Minor text/logging update