### PR TITLE
Tag dev releases as :latest

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -15,6 +15,19 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Define docker tag
+        id: define_docker_tag
+        run: |
+          ref_name=${{ github.ref_name }}
+          {
+            printf "tag="
+            if [[ "${ref_name}" == dev ]]; then
+              printf "latest"
+            else
+              printf "${ref_name}"
+            fi
+          } >> "$GITHUB_OUTPUT"
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -35,7 +48,7 @@ jobs:
           context: application
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ghcr.io/umccr/elsa-data:${{ github.ref_name }}
+            ghcr.io/umccr/elsa-data:${{ steps.define_docker_tag.outputs.tag }}
             ghcr.io/umccr/elsa-data:${{ github.sha }}
           build-args: |
             ELSA_DATA_VERSION=${{ github.ref_name }}


### PR DESCRIPTION
This PR makes it so that docker images built on the `dev` branch are tagged as `latest`. (This should've been in https://github.com/umccr/elsa-data/pull/82 but wasn't.)