### PR TITLE
Potential users need to be a thing

### DIFF
--- a/application/backend/dbschema/migrations/00001.edgeql
+++ b/application/backend/dbschema/migrations/00001.edgeql
@@ -1,4 +1,4 @@
-CREATE MIGRATION m12btt7inahpd7l3srpfen2yspkixlitkrlvhqtjsynenvibgeqcza
+CREATE MIGRATION m1nv55thvouf4q54d2x2fw5m24u7n7vo3ps6vcc674wklv7yoqvvsa
     ONTO initial
 {
   CREATE MODULE audit IF NOT EXISTS;
@@ -249,6 +249,17 @@ CREATE MIGRATION m12btt7inahpd7l3srpfen2yspkixlitkrlvhqtjsynenvibgeqcza
       };
       CREATE PROPERTY platform -> std::str;
       CREATE PROPERTY runDate -> std::datetime;
+  };
+  CREATE TYPE permission::PotentialUser {
+      CREATE MULTI LINK futureReleaseParticipant -> release::Release {
+          ON TARGET DELETE ALLOW;
+          CREATE PROPERTY role -> std::str {
+              CREATE CONSTRAINT std::one_of('DataOwner', 'Member', 'PI');
+          };
+      };
+      CREATE PROPERTY displayName -> std::str;
+      CREATE PROPERTY email -> std::str;
+      CREATE PROPERTY subjectId -> std::str;
   };
   CREATE TYPE permission::User {
       CREATE MULTI LINK releaseParticipant -> release::Release {

--- a/application/backend/dbschema/permission.esdl
+++ b/application/backend/dbschema/permission.esdl
@@ -1,5 +1,32 @@
 module permission {
 
+    # we need to support user as abstract/potential users - that get mentioned in DAC applications etc
+    # by email address - but who have not yet ever logged into Elsa Data and so have not become
+    # concrete users
+
+    type PotentialUser {
+
+        property subjectId -> str;
+        property displayName -> str;
+        property email -> str;
+
+        # whether this user will become a participant of a release when they login
+
+        multi link futureReleaseParticipant -> release::Release {
+            property role -> str {
+               constraint one_of('DataOwner', 'Member', 'PI');
+            }
+
+            # allow releases to be removed - all that happens for the user is they lose involvement with that release
+            # (in general releases won't be deleted anyway)
+            #
+            on target delete allow;
+        }
+
+    }
+
+
+
     type User {
 
         required property subjectId -> str {

--- a/application/backend/src/auth/auth-routes.ts
+++ b/application/backend/src/auth/auth-routes.ts
@@ -220,7 +220,11 @@ export const authRoutes = async (
     // that is - they are a deployment instance level setting
     const isa = isSuperAdmin(settings, authUser);
 
-    if (isa) allowed.add(ALLOWED_CHANGE_ADMINS);
+    if (isa) {
+      allowed.add(ALLOWED_CHANGE_ADMINS);
+      // for the moment if we want to do demos it is easy if the super admins get all the functionality
+      allowed.add(ALLOWED_CREATE_NEW_RELEASES);
+    }
 
     // some garbage temporary logic for giving extra permissions to some people
     // this would normally come via group info

--- a/application/backend/src/business/db/release-queries.ts
+++ b/application/backend/src/business/db/release-queries.ts
@@ -1,11 +1,5 @@
 import e from "../../../dbschema/edgeql-js";
 
-const rs = e
-  .select(e.release.Release, (r) => ({
-    filter: e.op(r.id, "=", e.uuid("")),
-  }))
-  .assert_single().datasetUris;
-
 /**
  * An EdgeDb query for all the dataset details for those datasets
  * associated with a given release.
@@ -44,7 +38,7 @@ export const allReleasesSummaryByUserQuery = e.params(
         (u) => ({
           id: true,
           filter: e.op(u.id, "=", params.userDbId),
-          // got to work out how to extract the link property values.. this was broken in Edge pre 2.0
+          // got to work out how to extract the link property values... this was broken in Edge pre 2.0
           // "@role": true
         })
       ),

--- a/application/backend/src/business/db/user-queries.ts
+++ b/application/backend/src/business/db/user-queries.ts
@@ -19,6 +19,51 @@ export type SingleUserBySubjectIdType = $infer<
 >;
 
 /**
+ * Return the details of a single user searching by display name.
+ * (NOTE: this is a temporary place holder until we add an email field in user - this will be replaced entirely by that)
+ * NOTE: we match the first! match here (because display name is not unique)
+ */
+export const singleUserByDisplayNameQuery = e.params(
+  { displayName: e.str },
+  (params) =>
+    e
+      .select(e.permission.User, (u) => ({
+        ...e.permission.User["*"],
+        filter: e.op(params.displayName, "=", u.displayName),
+        limit: 1,
+      }))
+      .assert_single()
+);
+
+/**
+ * Return the details of a single user searching by display name.
+ * (NOTE: this is a temporary place holder until we add an email field in user - this will be replaced entirely by that)
+ * NOTE: we match the first! match here (because display name is not unique)
+ */
+export const singlePotentialUserByDisplayNameQuery = e.params(
+  { displayName: e.str },
+  (params) =>
+    e
+      .select(e.permission.PotentialUser, (pu) => ({
+        ...e.permission.PotentialUser["*"],
+        futureReleaseParticipant: {
+          id: true,
+        },
+        filter: e.op(params.displayName, "=", pu.displayName),
+        limit: 1,
+      }))
+      .assert_single()
+);
+
+export const deletePotentialUserByDisplayNameQuery = e.params(
+  { displayName: e.str },
+  (params) =>
+    e.delete(e.permission.PotentialUser, (pu) => ({
+      filter: e.op(params.displayName, "=", pu.displayName),
+    }))
+);
+
+/**
  * A count of all users.
  */
 export const countAllUserQuery = e.count(e.permission.User);


### PR DESCRIPTION
Because we will be processing DAC applications (that mention users by name, email etc) - but *before* the user has ever interacted with Elsa Data - we need a way to park their user details and reassociate the first time they log in.
