### PR TITLE
Fix CSV import for AG

### DIFF
--- a/application/frontend/src/app.tsx
+++ b/application/frontend/src/app.tsx
@@ -22,7 +22,18 @@ function NoMatch() {
     <ErrorDisplay
       message={
         <div>
-          No React router match for <code>{location.pathname}</code>
+          <p>
+            No React router match for <code>{location.pathname}</code>
+          </p>
+          <p>
+            If you have landed on this page by following links within Elsa Data
+            - then this is an internal bug and we would be grateful if you could
+            report it.
+          </p>
+          <p>
+            If you have just been randomly typing in URLs then you have got what
+            you deserved!
+          </p>
         </div>
       }
     />

--- a/application/frontend/src/components/error-display.tsx
+++ b/application/frontend/src/components/error-display.tsx
@@ -1,25 +1,18 @@
-import React from "react";
+import React, { ReactNode } from "react";
 
 export type ErrorDisplayProps = {
-  message: JSX.Element;
+  message: ReactNode | undefined;
 };
 
 /**
  * Display an error message.
  */
-export const ErrorDisplay = ({ message }: ErrorDisplayProps): JSX.Element => {
-  return (
-    <div>
-      <p>{message}</p>
-      <p>
-        If you have landed on this page by following links within Elsa Data -
-        then this is an internal bug and we would be grateful if you could
-        report it.
-      </p>
-      <p>
-        If you have just been randomly typing in URLs then you have got what you
-        deserved!
-      </p>
+export const ErrorDisplay = ({
+  message,
+}: ErrorDisplayProps): JSX.Element | null => {
+  return message ? (
+    <div className="p-4 mx-4 my-3 text-sm text-red-700 bg-red-100 rounded-lg">
+      <span>{message}</span>
     </div>
-  );
+  ) : null;
 };

--- a/application/frontend/src/components/select-dialog-base.tsx
+++ b/application/frontend/src/components/select-dialog-base.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, MutableRefObject, ReactNode } from "react";
 import { Dialog, Transition } from "@headlessui/react";
+import { ErrorDisplay } from "./error-display";
 
 type Props = {
   showing: boolean;
@@ -65,14 +66,7 @@ export const SelectDialogBase: React.FC<Props> = ({
                     {content}
                   </div>
                 </div>
-                {errorMessage && (
-                  <div
-                    className="p-4 mx-4 my-3 text-sm text-red-700 bg-red-100 rounded-lg"
-                    role="alert"
-                  >
-                    <span className="font-medium">Error</span> {errorMessage}
-                  </div>
-                )}
+                <ErrorDisplay message={errorMessage} />
                 <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
                   {buttons}
                 </div>

--- a/application/frontend/src/pages/dac-import/australian-genomics-dac-redcap/australian-genomics-dac-redcap-upload-div.tsx
+++ b/application/frontend/src/pages/dac-import/australian-genomics-dac-redcap/australian-genomics-dac-redcap-upload-div.tsx
@@ -26,6 +26,7 @@ async function parseCsv<T extends File>(
       error: (error) => {
         return reject([error]);
       },
+      skipEmptyLines: "greedy",
     });
   });
 }

--- a/application/frontend/src/pages/dac-import/australian-genomics-dac-redcap/australian-genomics-dac-redcap-upload-div.tsx
+++ b/application/frontend/src/pages/dac-import/australian-genomics-dac-redcap/australian-genomics-dac-redcap-upload-div.tsx
@@ -48,6 +48,8 @@ function formatError(
 
   if (err instanceof Error) {
     parseErrorSetter(err.message);
+  } else if (typeof err === "string") {
+    parseErrorSetter(err);
   } else {
     parseErrorSetter(GENERIC_ERR_MSG);
   }
@@ -76,8 +78,12 @@ async function onDropCallback<T extends File>(
 
   const parseCsvPromises = acceptedFiles.map((f) => parseCsv<T>(f));
   const parsedPromises =
-    (await Promise.all(parseCsvPromises).catch((err: any) => {
-      formatError(err, parseErrorSetter, showingRedcapDialogSetter);
+    (await Promise.all(parseCsvPromises).catch((_: any) => {
+      formatError(
+        `${GENERIC_ERR_MSG} while parsing CSV file`,
+        parseErrorSetter,
+        showingRedcapDialogSetter
+      );
     })) ?? undefined;
 
   if (!parsedPromises) {

--- a/application/frontend/src/pages/dac-import/rems-dac/releases-dashboard-add-release-dialog.tsx
+++ b/application/frontend/src/pages/dac-import/rems-dac/releases-dashboard-add-release-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
 import axios from "axios";
 import { RemsApprovedApplicationType } from "@umccr/elsa-types";


### PR DESCRIPTION
Fixes #112

### Changes
* Fixes bug which doesn't render an exception box when parsing an invalid CSV file.
* Allows parsing CSV files with empty lines and whitespace-only lines.
* Uses the `ErrorDisplay` component when rendering errors in the `SelectDialogBase` component.

Related to #114 as it improves the `ErrorDisplay` box by introducing red text and background.