### PR TITLE
issue#97 - Record Email field and PotentialUser fix

### DIFF
--- a/application/backend/dbschema/migrations/00004.edgeql
+++ b/application/backend/dbschema/migrations/00004.edgeql
@@ -1,0 +1,24 @@
+CREATE MIGRATION m14niccvkffi63d26dh5u2fnvbxisijg2uu3gwi5ham3rixe7nrhma
+    ONTO m17ysf4t5jsztke5s55zbnnwnrt6fr7kgkee5eylmkt4ufwkfsaamq
+{
+  ALTER TYPE permission::PotentialUser {
+      ALTER PROPERTY email {
+          CREATE CONSTRAINT std::exclusive;
+      };
+      ALTER PROPERTY email {
+          SET readonly := true;
+          SET REQUIRED USING (SELECT
+              <std::str>permission::PotentialUser.displayName
+          );
+      };
+  };
+  ALTER TYPE permission::User {
+      CREATE REQUIRED PROPERTY email -> std::str {
+          SET readonly := true;
+          SET REQUIRED USING (SELECT
+              <std::str>permission::User.displayName
+          );
+          CREATE CONSTRAINT std::exclusive;
+      };
+  };
+};

--- a/application/backend/dbschema/migrations/00004.edgeql
+++ b/application/backend/dbschema/migrations/00004.edgeql
@@ -1,9 +1,9 @@
-CREATE MIGRATION m14niccvkffi63d26dh5u2fnvbxisijg2uu3gwi5ham3rixe7nrhma
+CREATE MIGRATION m1xrjtf74ctw3zx23f7f2cq4rtzfyrjsxhhqv76o5qqotrn7t563eq
     ONTO m17ysf4t5jsztke5s55zbnnwnrt6fr7kgkee5eylmkt4ufwkfsaamq
 {
   ALTER TYPE permission::PotentialUser {
       ALTER PROPERTY email {
-          CREATE CONSTRAINT std::exclusive;
+          CREATE CONSTRAINT std::exclusive ON (std::str_lower(__subject__));
       };
       ALTER PROPERTY email {
           SET readonly := true;
@@ -18,7 +18,7 @@ CREATE MIGRATION m14niccvkffi63d26dh5u2fnvbxisijg2uu3gwi5ham3rixe7nrhma
           SET REQUIRED USING (SELECT
               <std::str>permission::User.displayName
           );
-          CREATE CONSTRAINT std::exclusive;
+          CREATE CONSTRAINT std::exclusive ON (std::str_lower(__subject__));
       };
   };
 };

--- a/application/backend/dbschema/permission.esdl
+++ b/application/backend/dbschema/permission.esdl
@@ -9,7 +9,7 @@ module permission {
         property subjectId -> str;
         property displayName -> str;
         required property email -> str {
-            constraint exclusive;
+            constraint exclusive on (str_lower(__subject__));
             readonly := true;
         }
 
@@ -41,7 +41,7 @@ module permission {
         }
 
         required property email -> str {
-            constraint exclusive;
+            constraint exclusive on (str_lower(__subject__));
             readonly := true;
         }
 

--- a/application/backend/dbschema/permission.esdl
+++ b/application/backend/dbschema/permission.esdl
@@ -8,7 +8,11 @@ module permission {
 
         property subjectId -> str;
         property displayName -> str;
-        property email -> str;
+        required property email -> str {
+            constraint exclusive;
+            readonly := true;
+        }
+
 
         # whether this user will become a participant of a release when they login
 
@@ -33,6 +37,11 @@ module permission {
             # all user subjectIds must be unique
             constraint exclusive;
             constraint min_len_value(6);
+            readonly := true;
+        }
+
+        required property email -> str {
+            constraint exclusive;
             readonly := true;
         }
 

--- a/application/backend/src/auth/auth-routes.ts
+++ b/application/backend/src/auth/auth-routes.ts
@@ -183,7 +183,8 @@ export const authRoutes = async (
 
     const authUser = await userService.upsertUserForLogin(
       idClaims.sub,
-      displayName
+      displayName,
+      email
     );
 
     if (!authUser) {

--- a/application/backend/src/auth/auth-routes.ts
+++ b/application/backend/src/auth/auth-routes.ts
@@ -178,7 +178,6 @@ export const authRoutes = async (
     const idClaims = tokenSet.claims();
 
     const displayName = idClaims.name || "No Display Name";
-    // TODO we don't save email yet - but we should
     const email = idClaims.email || "No Email";
 
     const authUser = await userService.upsertUserForLogin(

--- a/application/backend/src/business/authenticated-user.ts
+++ b/application/backend/src/business/authenticated-user.ts
@@ -11,6 +11,7 @@ export class AuthenticatedUser {
       isNil(this.dbUser.id) ||
       isNil(this.dbUser.subjectId) ||
       isNil(this.dbUser.displayName) ||
+      isNil(this.dbUser.email) ||
       isNil(this.dbUser.lastLoginDateTime) ||
       isNil(this.dbUser.allowedCreateRelease) ||
       isNil(this.dbUser.allowedChangeReleaseDataOwner) ||
@@ -40,6 +41,10 @@ export class AuthenticatedUser {
    */
   public get displayName(): string {
     return this.dbUser!.displayName;
+  }
+
+  public get email(): string {
+    return this.dbUser!.email;
   }
 
   public get allowedCreateRelease(): boolean {

--- a/application/backend/src/business/db/user-queries.ts
+++ b/application/backend/src/business/db/user-queries.ts
@@ -26,7 +26,6 @@ export const singleUserByEmailQuery = e.params({ email: e.str }, (params) =>
     .select(e.permission.User, (u) => ({
       ...e.permission.User["*"],
       filter: e.op(params.email, "=", u.email),
-      limit: 1,
     }))
     .assert_single()
 );
@@ -44,7 +43,6 @@ export const singlePotentialUserByEmailQuery = e.params(
           id: true,
         },
         filter: e.op(params.email, "=", pu.email),
-        limit: 1,
       }))
       .assert_single()
 );

--- a/application/backend/src/business/db/user-queries.ts
+++ b/application/backend/src/business/db/user-queries.ts
@@ -20,28 +20,22 @@ export type SingleUserBySubjectIdType = $infer<
 
 /**
  * Return the details of a single user searching by display name.
- * (NOTE: this is a temporary place holder until we add an email field in user - this will be replaced entirely by that)
- * NOTE: we match the first! match here (because display name is not unique)
  */
-export const singleUserByDisplayNameQuery = e.params(
-  { displayName: e.str },
-  (params) =>
-    e
-      .select(e.permission.User, (u) => ({
-        ...e.permission.User["*"],
-        filter: e.op(params.displayName, "=", u.displayName),
-        limit: 1,
-      }))
-      .assert_single()
+export const singleUserByEmailQuery = e.params({ email: e.str }, (params) =>
+  e
+    .select(e.permission.User, (u) => ({
+      ...e.permission.User["*"],
+      filter: e.op(params.email, "=", u.email),
+      limit: 1,
+    }))
+    .assert_single()
 );
 
 /**
  * Return the details of a single user searching by display name.
- * (NOTE: this is a temporary place holder until we add an email field in user - this will be replaced entirely by that)
- * NOTE: we match the first! match here (because display name is not unique)
  */
-export const singlePotentialUserByDisplayNameQuery = e.params(
-  { displayName: e.str },
+export const singlePotentialUserByEmailQuery = e.params(
+  { email: e.str },
   (params) =>
     e
       .select(e.permission.PotentialUser, (pu) => ({
@@ -49,17 +43,17 @@ export const singlePotentialUserByDisplayNameQuery = e.params(
         futureReleaseParticipant: {
           id: true,
         },
-        filter: e.op(params.displayName, "=", pu.displayName),
+        filter: e.op(params.email, "=", pu.email),
         limit: 1,
       }))
       .assert_single()
 );
 
-export const deletePotentialUserByDisplayNameQuery = e.params(
-  { displayName: e.str },
+export const deletePotentialUserByEmailQuery = e.params(
+  { email: e.str },
   (params) =>
     e.delete(e.permission.PotentialUser, (pu) => ({
-      filter: e.op(params.displayName, "=", pu.displayName),
+      filter: e.op(params.email, "=", pu.email),
     }))
 );
 

--- a/application/backend/src/business/db/user-queries.ts
+++ b/application/backend/src/business/db/user-queries.ts
@@ -19,7 +19,7 @@ export type SingleUserBySubjectIdType = $infer<
 >;
 
 /**
- * Return the details of a single user searching by display name.
+ * Return the details of a single user searching by email.
  */
 export const singleUserByEmailQuery = e.params({ email: e.str }, (params) =>
   e
@@ -32,7 +32,7 @@ export const singleUserByEmailQuery = e.params({ email: e.str }, (params) =>
 );
 
 /**
- * Return the details of a single user searching by display name.
+ * Return the details of a single user searching by email.
  */
 export const singlePotentialUserByEmailQuery = e.params(
   { email: e.str },

--- a/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
+++ b/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
@@ -310,8 +310,7 @@ ${roleTable.join("\n")}
         });
 
         if (dbUser) {
-          // adding a role link into an existing user
-
+          // Adding a role link into an existing user.
           await e
             .update(e.permission.User, (u) => ({
               filter: e.op(e.uuid(dbUser.id), "=", u.id),
@@ -326,7 +325,7 @@ ${roleTable.join("\n")}
             }))
             .run(t);
         } else if (potentialDbUser) {
-          // Adding to existing potentialUser that has been created
+          // Adding a role to an existing potentialUser record.
           await e
             .update(e.permission.PotentialUser, (pu) => ({
               filter: e.op(e.uuid(potentialDbUser.id), "=", pu.id),
@@ -341,7 +340,7 @@ ${roleTable.join("\n")}
             }))
             .run(t);
         } else {
-          // A brand new potentialUser must be created
+          // A brand new potentialUser with a link role to the release
           await e
             .insert(e.permission.PotentialUser, {
               displayName: au.displayName,

--- a/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
+++ b/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
@@ -12,7 +12,8 @@ import { ElsaSettings } from "../../../config/elsa-settings";
 import { AustraliaGenomicsDacRedcap } from "@umccr/elsa-types/csv-australian-genomics";
 import { format } from "date-fns";
 import {
-  singleUserByDisplayNameQuery,
+  singlePotentialUserByEmailQuery,
+  singleUserByEmailQuery,
   singleUserBySubjectIdQuery,
 } from "../../db/user-queries";
 import { generate } from "randomstring";
@@ -300,16 +301,20 @@ ${roleTable.join("\n")}
         au: ApplicationUser,
         role: string
       ) => {
-        // has this user already logged in to Elsa?
-        const dbUser = await singleUserByDisplayNameQuery.run(t, {
-          displayName: au.displayName,
+        // Find if user had logged in to elsa
+        const dbUser = await singleUserByEmailQuery.run(t, {
+          email: au.email,
+        });
+        const potentialDbUser = await singlePotentialUserByEmailQuery.run(t, {
+          email: au.email,
         });
 
         if (dbUser) {
           // adding a role link into an existing user
+
           await e
             .update(e.permission.User, (u) => ({
-              filter: e.op(e.uuid(user.dbId), "=", u.id),
+              filter: e.op(e.uuid(dbUser.id), "=", u.id),
               set: {
                 releaseParticipant: {
                   "+=": e.select(e.release.Release, (r) => ({
@@ -320,10 +325,24 @@ ${roleTable.join("\n")}
               },
             }))
             .run(t);
+        } else if (potentialDbUser) {
+          // Adding to existing potentialUser that has been created
+          await e
+            .update(e.permission.PotentialUser, (pu) => ({
+              filter: e.op(e.uuid(potentialDbUser.id), "=", pu.id),
+              set: {
+                futureReleaseParticipant: {
+                  "+=": e.select(e.release.Release, (r) => ({
+                    filter: e.op(e.uuid(newRelease.id), "=", r.id),
+                    "@role": e.str(role),
+                  })),
+                },
+              },
+            }))
+            .run(t);
         } else {
-          // TODO: the case of a potential user already existing.. this will have to wait until
-          // we have an 'email' property to make exclusive constraint
-          const potentialDbUser = await e
+          // A brand new potentialUser must be created
+          await e
             .insert(e.permission.PotentialUser, {
               displayName: au.displayName,
               email: au.email,

--- a/application/backend/src/test-data/insert-test-data.ts
+++ b/application/backend/src/test-data/insert-test-data.ts
@@ -85,7 +85,7 @@ export async function insertTestData(settings: ElsaSettings) {
   await createTestUser(
     TEST_SUBJECT_1,
     "Test User 1",
-    "user1@elsa.com",
+    "subject1@elsa.net",
     [r1.id, r4.id],
     [r2.id],
     []
@@ -93,7 +93,7 @@ export async function insertTestData(settings: ElsaSettings) {
   await createTestUser(
     TEST_SUBJECT_2,
     "Test User 2",
-    "user2@elsa.com",
+    "subject2@elsa.net",
     [],
     [r1.id],
     []
@@ -101,7 +101,7 @@ export async function insertTestData(settings: ElsaSettings) {
   await createTestUser(
     TEST_SUBJECT_3,
     "Test User 3",
-    "user3@elsa.com",
+    "subject3@elsa.net",
     [],
     [],
     []

--- a/application/backend/src/test-data/insert-test-data.ts
+++ b/application/backend/src/test-data/insert-test-data.ts
@@ -85,12 +85,27 @@ export async function insertTestData(settings: ElsaSettings) {
   await createTestUser(
     TEST_SUBJECT_1,
     "Test User 1",
+    "user1@elsa.com",
     [r1.id, r4.id],
     [r2.id],
     []
   );
-  await createTestUser(TEST_SUBJECT_2, "Test User 2", [], [r1.id], []);
-  await createTestUser(TEST_SUBJECT_3, "Test User 3", [], [], []);
+  await createTestUser(
+    TEST_SUBJECT_2,
+    "Test User 2",
+    "user2@elsa.com",
+    [],
+    [r1.id],
+    []
+  );
+  await createTestUser(
+    TEST_SUBJECT_3,
+    "Test User 3",
+    "user3@elsa.com",
+    [],
+    [],
+    []
+  );
 
   console.log(
     `  Number of object artifacts present = ${await e

--- a/application/backend/src/test-data/test-data-helpers.ts
+++ b/application/backend/src/test-data/test-data-helpers.ts
@@ -95,6 +95,7 @@ export function makeTripleCodeArray(
 export async function createTestUser(
   subjectId: string,
   displayName: string,
+  email: string,
   releasesAsDataOwner: string[],
   releasesAsPI: string[],
   releasesAsMember: string[]
@@ -104,6 +105,7 @@ export async function createTestUser(
     .insert(e.permission.User, {
       subjectId: subjectId,
       displayName: displayName,
+      email: email,
       allowedChangeReleaseDataOwner: false,
       allowedCreateRelease: false,
       allowedImportDataset: false,

--- a/application/backend/tests/service-tests/ag-redcap-import.test.ts
+++ b/application/backend/tests/service-tests/ag-redcap-import.test.ts
@@ -50,8 +50,6 @@ describe("Redcap Import for AG", () => {
 
     await redcapImportService.startNewRelease(allowedDataOwnerUser, app);
 
-    await usersService.upsertUserForLogin("asadasdfsf", "Albus Dumbledore");
-
     const potentialCount = await e
       .count(e.permission.PotentialUser)
       .run(edgedbClient);
@@ -81,7 +79,7 @@ describe("Redcap Import for AG", () => {
       daf_applicant_pi_yn: "0",
       // but we have an explicit PI - that we know!
       daf_pi_name: "Test User Who Isn't Allowed Any Access",
-      daf_pi_email: "test@example.com",
+      daf_pi_email: "subject1@elsa.net",  // refer to release.common.ts file
       daf_pi_institution: "Made Up",
       daf_pi_institution_same: "0",
       // one other collaborator (who is unknown)

--- a/application/backend/tests/service-tests/dataset.common.ts
+++ b/application/backend/tests/service-tests/dataset.common.ts
@@ -7,7 +7,7 @@ import {
   makeSingleCodeArray,
   makeSystemlessIdentifier,
 } from "../../src/test-data/test-data-helpers";
-import { insert10F, TENF_URI } from "../../src/test-data/insert-test-data-10f";
+import { insert10F } from "../../src/test-data/insert-test-data-10f";
 
 /**
  * This is a common beforeEach call that should be used to setup a base
@@ -27,11 +27,13 @@ export async function beforeEachCommon() {
 
   // TODO: we don't have an admin model for datasets yet so this is very simple
   const allowedPiSubject = "http://subject1.com";
+  const allowedPiEmail = "admin-user@elsa.net";
 
   const allowedPiUserInsert = await e
     .insert(e.permission.User, {
       subjectId: allowedPiSubject,
       displayName: "Test User Who Is An Admin",
+      email: allowedPiEmail,
     })
     .run(edgeDbClient);
 
@@ -39,6 +41,11 @@ export async function beforeEachCommon() {
     id: allowedPiUserInsert.id,
     subjectId: allowedPiSubject,
     displayName: "Allowed PI",
+    email: allowedPiEmail,
+    allowedChangeReleaseDataOwner: true,
+    allowedCreateRelease: true,
+    allowedImportDataset: true,
+    lastLoginDateTime: new Date(),
   });
 
   return {

--- a/application/backend/tests/service-tests/releases.common.ts
+++ b/application/backend/tests/service-tests/releases.common.ts
@@ -101,11 +101,13 @@ export async function beforeEachCommon() {
   {
     const allowedDataOwnerSubject = "https://i-am-admin.org";
     const allowedDisplayName = "Test User Who Is Allowed Data Owner Access";
+    const allowedEmail = "admin@elsa.net";
 
     const allowedDataOwnerUserInsert = await e
       .insert(e.permission.User, {
         subjectId: allowedDataOwnerSubject,
         displayName: allowedDisplayName,
+        email: allowedEmail,
         releaseParticipant: e.select(e.release.Release, (r) => ({
           filter: e.op(e.uuid(testReleaseId), "=", r.id),
           "@role": e.str("DataOwner"),
@@ -117,6 +119,7 @@ export async function beforeEachCommon() {
       id: allowedDataOwnerUserInsert.id,
       subjectId: allowedDataOwnerSubject,
       displayName: allowedDisplayName,
+      email: allowedEmail,
       lastLoginDateTime: new Date(),
       allowedImportDataset: false,
       allowedChangeReleaseDataOwner: false,
@@ -128,11 +131,13 @@ export async function beforeEachCommon() {
   {
     const allowedPiSubject = "http://subject1.com";
     const allowedDisplayName = "Test User Who Is Allowed PI Access";
+    const allowedEmail = "subject1@elsa.net";
 
     const allowedPiUserInsert = await e
       .insert(e.permission.User, {
         subjectId: allowedPiSubject,
         displayName: allowedDisplayName,
+        email: allowedEmail,
         releaseParticipant: e.select(e.release.Release, (r) => ({
           filter: e.op(e.uuid(testReleaseId), "=", r.id),
           "@role": e.str("PI"),
@@ -144,6 +149,7 @@ export async function beforeEachCommon() {
       id: allowedPiUserInsert.id,
       subjectId: allowedPiSubject,
       displayName: allowedDisplayName,
+      email: allowedEmail,
       lastLoginDateTime: new Date(),
       allowedImportDataset: false,
       allowedChangeReleaseDataOwner: false,
@@ -155,10 +161,12 @@ export async function beforeEachCommon() {
   {
     const notAllowedSubject = "http://subject3.com";
     const notAllowedDisplayName = "Test User Who Isn't Allowed Any Access";
+    const notAllowedEmail = "subject3@elsa.net";
 
     const notAllowedUserInsert = await e
       .insert(e.permission.User, {
         subjectId: notAllowedSubject,
+        email: notAllowedEmail,
         displayName: "Test User Who Isn't Allowed Any Access",
       })
       .run(edgeDbClient);
@@ -167,6 +175,7 @@ export async function beforeEachCommon() {
       id: notAllowedUserInsert.id,
       subjectId: notAllowedSubject,
       displayName: notAllowedDisplayName,
+      email: notAllowedEmail,
       lastLoginDateTime: new Date(),
       allowedImportDataset: false,
       allowedChangeReleaseDataOwner: false,

--- a/application/backend/tests/service-tests/user.common.ts
+++ b/application/backend/tests/service-tests/user.common.ts
@@ -17,11 +17,13 @@ export async function beforeEachCommon() {
 
   const allowedPiSubject = "http://subject1.com";
   const allowedPiDisplayName = "Test User Who Is An Admin";
+  const allowedPiEmail = "subject1@elsa.net";
 
   const allowedPiUserInsert = await e
     .insert(e.permission.User, {
       subjectId: allowedPiSubject,
       displayName: allowedPiDisplayName,
+      email: allowedPiEmail,
     })
     .run(edgeDbClient);
 
@@ -29,6 +31,11 @@ export async function beforeEachCommon() {
     id: allowedPiUserInsert.id,
     subjectId: allowedPiSubject,
     displayName: allowedPiDisplayName,
+    email: allowedPiEmail,
+    allowedChangeReleaseDataOwner: true,
+    allowedCreateRelease: true,
+    allowedImportDataset: true,
+    lastLoginDateTime: new Date(),
   });
 
   return {


### PR DESCRIPTION
- Record `Email` for permission::User from CiLogon attributes
- Change query by `email` instead of temporary `displayName`
- Properly link potentialUser from `startNewRelaese` redcap function
- Some test cases update