### PR TITLE
Allow setting host in elsa settings

### DIFF
--- a/application/backend/jobs/select-job.ts
+++ b/application/backend/jobs/select-job.ts
@@ -26,6 +26,7 @@ const fakeSettings: ElsaSettings = {
   oidcClientSecret: "",
   oidcIssuer: new Issuer({ issuer: "" }),
   ontoFhirUrl: "",
+  host: "127.0.0.1",
   port: 3000,
   datasets: [],
   superAdmins: [],

--- a/application/backend/src/bootstrap-settings.ts
+++ b/application/backend/src/bootstrap-settings.ts
@@ -54,6 +54,7 @@ export async function bootstrapSettings(config: any): Promise<ElsaSettings> {
 
   return {
     deployedUrl: deployedUrl,
+    host: config.get("host"),
     port: config.get("port"),
     oidcClientId: config.get("oidc.clientId")!,
     oidcClientSecret: config.get("oidc.clientSecret")!,

--- a/application/backend/src/config/config-constants.ts
+++ b/application/backend/src/config/config-constants.ts
@@ -110,6 +110,13 @@ export const configDefinition = {
     format: "*",
     default: "",
   },
+  host: {
+    doc: "The host to bind.",
+    format: "*",
+    default: "0.0.0.0",
+    env: `${env_prefix}HOST`,
+    arg: "host",
+  },
   port: {
     doc: "The port to bind.",
     format: "port",

--- a/application/backend/src/config/elsa-settings.ts
+++ b/application/backend/src/config/elsa-settings.ts
@@ -10,6 +10,7 @@ export type ElsaSettings = {
   // the URL by which this instance is found - used for generating email links and OIDC redirects etc
   deployedUrl: string;
 
+  host: string;
   port: number;
 
   sessionSecret: string;

--- a/application/backend/src/entrypoint-command-start-web-server.ts
+++ b/application/backend/src/entrypoint-command-start-web-server.ts
@@ -68,12 +68,12 @@ export async function startWebServer(scenario: number | null): Promise<number> {
 
   const server = await app.setupServer();
 
-  console.log(`Listening on 0.0.0.0 on port ${settings.port}`);
+  console.log(`Listening on ${settings.host} on port ${settings.port}`);
 
   try {
     // this waits until the server has started up - but does not wait for the server to close down
     // to best support Docker - which will be our normal deployment - we listen on 0.0.0.0
-    await server.listen({ port: settings.port, host: "0.0.0.0" });
+    await server.listen({ port: settings.port, host: settings.host });
 
     // TODO possibly replace Bree with our own direct Jobs query and handle that here
 


### PR DESCRIPTION
The local test users do not work well with an ip address of `0.0.0.0`, so this PR allows setting the host in `ElsaSettings` to another value, such as `127.0.0.1`.