### PR TITLE
Don't paginate search results

### DIFF
--- a/application/frontend/src/pages/releases/detail/cases-box/cases-box.tsx
+++ b/application/frontend/src/pages/releases/detail/cases-box/cases-box.tsx
@@ -54,10 +54,11 @@ export const CasesBox: React.FC<Props> = ({
     ["releases-cases", currentPage, searchText, releaseId],
     async () => {
       const urlParams = new URLSearchParams();
-      urlParams.append("page", currentPage.toString());
       const useableSearchText = makeUseableSearchText(searchText);
       if (useableSearchText) {
         urlParams.append("q", useableSearchText);
+      } else {
+        urlParams.append("page", currentPage.toString());
       }
       const u = `/api/releases/${releaseId}/cases?${urlParams.toString()}`;
       return await axios.get<ReleaseCaseType[]>(u).then((response) => {


### PR DESCRIPTION
Potentially closes #113. Although #113, as written, seems to be describing a different issue that I can't reproduce. The issue I bumped into was instead that, if you navigate to a page other than the first then enter a search query, there won't be any search results. This is because the search box accesses the end point `/api/releases/${releaseId}/cases?page=<some-page>&q=<query-string>`, with `<some-page>` set to the page number at the time the query was entered into the text box. The query string should not contain `page=<some-page>`.