### PR TITLE
Remove duplicate `host:` key from `test-elsa-settings.common.ts`

### DIFF
--- a/application/backend/tests/test-elsa-settings.common.ts
+++ b/application/backend/tests/test-elsa-settings.common.ts
@@ -14,7 +14,6 @@ const ciLogonIssuer = new Issuer({
 export const createTestElsaSettings: () => ElsaSettings = () => ({
   // TODO these settings have just been thrown in - and may need to be refined as testing gets
   //      more sophisticated
-  host: "127.0.0.1",
   port: 3000,
   host: "127.0.0.1",
   deployedUrl: "http://localhost:3000",


### PR DESCRIPTION
#138 broke `origin/dev` by introducing a change which conflicted with #136.