### PR TITLE
ci: set install-links to false when using npm ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
             application/common/elsa-types
             application/backend
             application/frontend
+          install-command: npm ci --install-links=false
 
       # Install an EdgeDb for use by the tests
       #- uses: edgedb/setup-edgedb@8bc9e10005674ec772652b86e1fdd476e6462284

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
             application/common/elsa-types
             application/backend
             application/frontend
+          install-command: npm ci --install-links=false
 
       # unit tests can run first before any databases are set up
       - name: Run unit tests


### PR DESCRIPTION
This fixes the failing build and tests when the github action runs `npm ci`. 

It seems that there is a change between the `package-lock.json` files when running `npm install` with `--install-links=true` vs `--install-links=false`. Npm version `>=9.0.0` and `<9.4.2` has `--install-links=true`, whereas other versions do not. The version of node used in our CI build is `18.14.0`, which comes with npm `9.3.1`,  causing the build to fail when the `package-lock.json` is not generated with a compatible npm version. This was unintentionally a breaking change so `--install-links` was reverted back to `false` in npm `9.4.2`, see https://github.com/nodejs/node/issues/46542 and https://github.com/npm/cli/pull/6142.

This is also related to https://github.com/umccr/elsa-data/issues/176 - because of the way our project is setup, it needs `--install-links=false`, otherwise this issue occurs. I think this is because `--install-links=true` packs and builds a `file:` dependency like it would a regular dependency, rather than symlinking it and there is no build step in `elsa-types` or `elsa-constants` that transpiles the typescript, so this issue occurs. It might worth thinking about how to setup `elsa-types` and `elsa-constants` so that it works with `--install-links=true`, because newer versions of npm could have this as the default again. One way to do this is with a `tsc --build` script and [exporting](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) the correct parts of `elsa-types` and `elsa-constants`.

### TL;DR
* If you are using npm version `>=9.0.0` and `<9.4.2`, run `npm install` with `--install-links=false`, or use an npm version where `--install-links=false` by default, such as npm `9.4.2`.