### PR TITLE
GCP equivalent of AWS S3 Access Point Sharing

### DIFF
--- a/application/backend/package-lock.json
+++ b/application/backend/package-lock.json
@@ -65,6 +65,7 @@
         "moo": "^0.5.2",
         "nodemailer": "^6.8.0",
         "openid-client": "5.2.1",
+        "p-limit": "^3.1.0",
         "p-throttle": "^5.0.0",
         "patch-package": "6.4.7",
         "pino": "^8.7.0",

--- a/application/backend/package.json
+++ b/application/backend/package.json
@@ -93,6 +93,7 @@
     "moo": "^0.5.2",
     "nodemailer": "^6.8.0",
     "openid-client": "5.2.1",
+    "p-limit": "^3.1.0",
     "p-throttle": "^5.0.0",
     "patch-package": "6.4.7",
     "pino": "^8.7.0",

--- a/application/backend/src/business/services/gcp-presigned-urls-service.ts
+++ b/application/backend/src/business/services/gcp-presigned-urls-service.ts
@@ -21,8 +21,7 @@ export class GcpPresignedUrlsService
     @inject("Database") protected edgeDbClient: edgedb.Client,
     @inject("Settings") private settings: ElsaSettings,
     private releaseService: ReleaseService,
-    usersService: UsersService,
-    auditLogService: AuditLogService
+    usersService: UsersService
   ) {
     super();
 

--- a/application/backend/src/business/services/gcp-storage-sharing-service.ts
+++ b/application/backend/src/business/services/gcp-storage-sharing-service.ts
@@ -1,0 +1,268 @@
+import { AuthenticatedUser } from "../authenticated-user";
+import * as edgedb from "edgedb";
+import { inject, injectable, singleton } from "tsyringe";
+import { UsersService } from "./users-service";
+import { GcpBaseService } from "./gcp-base-service";
+import { AuditLogService } from "./audit-log-service";
+import { Storage } from "@google-cloud/storage";
+import {
+  getAllFileRecords,
+  ReleaseFileListEntry,
+} from "./_release-file-list-helper";
+import pLimit, { Limit } from "p-limit";
+import { Metadata } from "@google-cloud/storage/build/src/nodejs-common";
+
+@injectable()
+@singleton()
+export class GcpStorageSharingService extends GcpBaseService {
+  storage: Storage;
+  globalLimit: Limit;
+  objectLimits: { [uri: string]: Limit };
+
+  constructor(
+    @inject("Database") protected edgeDbClient: edgedb.Client,
+    private usersService: UsersService,
+    private auditLogService: AuditLogService
+  ) {
+    super();
+
+    this.storage = new Storage();
+
+    // GCP probably rate-limits API requests, otherwise their `Storage` library
+    // wouldn't have retry logic and tests for rate-limit exceptions.
+    // Unfortunately, I can't find the documentation to say what the limits are.
+    // A different GCP feature, OAuth, has a quota which is "Dependent on
+    // application history, developer reputation, and riskiness".
+    // (Source: https://support.google.com/cloud/answer/9028764?hl=en). So there
+    // might not be a concrete answer as to what the relevant limits are.
+    const concurrencyLimit = 10;
+    this.globalLimit = pLimit(concurrencyLimit);
+
+    // GCP will complain if we attempt to modify ACLs on the same object
+    // concurrently, so we'll make a queue for each object.
+    this.objectLimits = {};
+  }
+
+  /**
+   * GCP will raise an exception if one object has concurrent modifications
+   * made to it.
+   *
+   * @returns An object which enqueues operations on objects such that they happen one-at-a-time.
+   */
+  getObjectLimit(bucket: string, key: string): Limit {
+    const uri = `gs://${bucket}/${key}`;
+    if (!(uri in this.objectLimits)) {
+      this.objectLimits[uri] = pLimit(1);
+    }
+    return this.objectLimits[uri];
+  }
+
+  /**
+   * Adds/removes a metadata key-value pair to an object which indicates release
+   * membership.
+   *
+   * @param operation whether to add or delete the release's metadata
+   * @param bucket the bucket which the object belongs to
+   * @param key the object's key
+   * @param releaseId the release the object belongs to
+   */
+  modifyObjectMetadataFn(
+    operation: "add" | "delete",
+    bucket: string,
+    key: string,
+    releaseId: string
+  ): () => Promise<void> {
+    // TODO(DoxasticFox): Delete me when we start using the release service
+    // to figure out which objects belong to an active release
+    const go = async () => {
+      const metadataKey = `elsa-data-release-id-${releaseId}`;
+
+      var updatedMetadata: Metadata = {};
+
+      if (operation === "add") {
+        updatedMetadata = {
+          metadata: {
+            [metadataKey]: true,
+          },
+        };
+      } else if (operation === "delete") {
+        updatedMetadata = {
+          metadata: {
+            [metadataKey]: null,
+          },
+        };
+      } else {
+        throw Error(`Unexpected operation ${operation}`);
+      }
+
+      await this.storage.bucket(bucket).file(key).setMetadata(updatedMetadata);
+    };
+
+    const objectLimit = this.getObjectLimit(bucket, key);
+
+    return () => objectLimit(go);
+  }
+
+  modifyObjectPrincipalFn(
+    operation: "add" | "delete",
+    bucket: string,
+    key: string,
+    releaseId: string,
+    principal: string
+  ): () => Promise<void> {
+    const go = async () => {
+      await this.storage
+        .bucket(bucket)
+        .file(key)
+        .acl[operation]({
+          entity: `user-${principal}`,
+          role: Storage.acl.READER_ROLE,
+        });
+    };
+
+    const objectLimit = this.getObjectLimit(bucket, key);
+
+    return () => objectLimit(go);
+  }
+
+  modifyObjectPrincipalsFns(
+    operation: "add" | "delete",
+    bucket: string,
+    key: string,
+    releaseId: string,
+    principals: string[]
+  ): (() => Promise<void>)[] {
+    return [
+      ...principals.map((principal) =>
+        this.modifyObjectPrincipalFn(
+          operation,
+          bucket,
+          key,
+          releaseId,
+          principal
+        )
+      ),
+      this.modifyObjectMetadataFn(operation, bucket, key, releaseId),
+    ];
+  }
+
+  modifyObjectsPrincipalsFns(
+    operation: "add" | "delete",
+    allFiles: ReleaseFileListEntry[],
+    releaseId: string,
+    principals: string[]
+  ): (() => Promise<void>)[] {
+    return allFiles.flatMap((f) =>
+      this.modifyObjectPrincipalsFns(
+        operation,
+        f.objectStoreBucket,
+        f.objectStoreKey,
+        releaseId,
+        principals
+      )
+    );
+  }
+
+  /**
+   * Adds or deletes IAM ACLs from all the objects in a release. Additionally,
+   * metadata is added to or delete from the objects indicating which release
+   * they belong to.
+   *
+   * @param operation whether to add or delete IAM ACLs
+   * @param user
+   * @param releaseId The release containing the objects whose ACLs will be modified
+   * @param principals The IAM principals to be added or delete from the objects' ACLs
+   *
+   * @returns The number of objects modified
+   */
+  async modifyUsers(
+    operation: "add" | "delete",
+    user: AuthenticatedUser,
+    releaseId: string,
+    principals: string[]
+  ): Promise<number> {
+    const now = new Date();
+    const newAuditEventId = await this.auditLogService.startReleaseAuditEvent(
+      this.edgeDbClient,
+      user,
+      releaseId,
+      "E",
+      "Modified GCP object ACLs for release",
+      now
+    );
+
+    const allFiles = await getAllFileRecords(
+      this.edgeDbClient,
+      this.usersService,
+      user,
+      releaseId
+    );
+
+    const shareFns = this.modifyObjectsPrincipalsFns(
+      operation,
+      allFiles,
+      releaseId,
+      principals
+    );
+
+    const numberOfFilesModified = principals.length === 0 ? 0 : allFiles.length;
+
+    try {
+      await Promise.all(shareFns.map((fn) => this.globalLimit(fn)));
+    } catch (e) {
+      const errorString = e instanceof Error ? e.message : String(e);
+
+      await this.auditLogService.completeReleaseAuditEvent(
+        this.edgeDbClient,
+        newAuditEventId,
+        8,
+        now,
+        new Date(),
+        { error: errorString }
+      );
+
+      throw e;
+    }
+
+    await this.auditLogService.completeReleaseAuditEvent(
+      this.edgeDbClient,
+      newAuditEventId,
+      0,
+      now,
+      new Date(),
+      { numUrls: numberOfFilesModified }
+    );
+
+    return numberOfFilesModified;
+  }
+
+  async addUsers(
+    user: AuthenticatedUser,
+    releaseId: string,
+    principals: string[]
+  ): Promise<number> {
+    return await this.modifyUsers("add", user, releaseId, principals);
+  }
+
+  async deleteUsers(
+    user: AuthenticatedUser,
+    releaseId: string,
+    principals: string[]
+  ): Promise<number> {
+    return await this.modifyUsers("delete", user, releaseId, principals);
+  }
+
+  async manifest(
+    user: AuthenticatedUser,
+    releaseId: string,
+    tsvColumns: string[]
+  ): Promise<{ filename: string; content: string }> {
+    // TODO(DoxasticFox): Implement me. A manifest getter is already implemented
+    // here: application/backend/src/business/services/aws-access-point-service.ts
+    //
+    // Though, once it's implemented, it's probably better to use the release
+    // service which @andrewpatto started working on here:
+    // https://github.com/umccr/elsa-data/pull/186
+    return { filename: "", content: "" };
+  }
+}

--- a/application/frontend/src/pages/releases/detail/gcp-storage-iam-share-form.tsx
+++ b/application/frontend/src/pages/releases/detail/gcp-storage-iam-share-form.tsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import { ReleaseRemsSyncRequestType } from "@umccr/elsa-types";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import {
+  axiosPostArgMutationFn,
+  axiosPostNullMutationFn,
+  REACT_QUERY_RELEASE_KEYS,
+  specificReleaseQuery,
+} from "./queries";
+import axios from "axios";
+import { ReleaseTypeLocal } from "./shared-types";
+import { isUndefined } from "lodash";
+import { Checkbox, Label } from "flowbite-react";
+import { EagerErrorBoundary, ErrorState } from "../../../components/errors";
+
+type Props = {
+  releaseId: string;
+};
+
+type SuccessState = {
+  recordsUpdated: number;
+};
+
+/**
+ * A form that adds IAM permissions to objects in a GCP Storage bucket
+ *
+ * @param releaseId
+ * @constructor
+ */
+export const GcpStorageIamShareForm: React.FC<Props> = ({ releaseId }) => {
+  const queryClient = useQueryClient();
+
+  const [status, setStatus] = useState<
+    "ready" | "working" | SuccessState | ErrorState
+  >("ready");
+
+  const postAclUpdate = (url: string) => (data: { users: string[] }) => {
+    setStatus("working");
+    return axios
+      .post<void>(url, data)
+      .then((reply) => setStatus({ recordsUpdated: reply.data }))
+      .catch((error) =>
+        setStatus({ error: error?.response?.data ?? error, isSuccess: false })
+      );
+  };
+
+  const addAclUsersMutate = useMutation(
+    postAclUpdate(`/api/releases/${releaseId}/gcp-storage/acls/add`)
+  );
+
+  const removeAclUsersMutate = useMutation(
+    postAclUpdate(`/api/releases/${releaseId}/gcp-storage/acls/remove`)
+  );
+
+  const tsvColumnCheck = (field: string) => (
+    <div key={field} className="flex items-center gap-2">
+      <Checkbox
+        defaultChecked={true}
+        name="presignHeader"
+        id={`chx-${field}`}
+        value={field}
+      />
+      <Label className="uppercase" htmlFor={`chx-${field}`}>
+        {field}
+      </Label>
+    </div>
+  );
+
+  const [iamUsers, setIamUsers] = useState("");
+
+  const iamUsersArray = iamUsers.split(/[ ,]+/).filter((u) => u);
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4 divide-x">
+        <form>
+          <div className="flex flex-col gap-6">
+            <label className="prose block">
+              The functionality from the perspective of the data holder.
+            </label>
+            <label className="prose block">
+              <span className="text-xs font-bold uppercase text-gray-700">
+                IAM Users
+              </span>
+              <input
+                type="text"
+                value={iamUsers}
+                onChange={(e) => setIamUsers(e.target.value)}
+                className="mt-1 block w-full rounded-md border-transparent bg-gray-50 focus:border-gray-500 focus:bg-white focus:ring-0"
+              />
+            </label>
+            <div className="prose">
+              <button
+                type="button"
+                className="btn-normal"
+                onClick={() =>
+                  addAclUsersMutate.mutate({ users: iamUsersArray })
+                }
+              >
+                Add IAM Users
+              </button>
+            </div>
+            <div className="prose">
+              <button
+                type="button"
+                className="btn-normal"
+                onClick={() =>
+                  removeAclUsersMutate.mutate({ users: iamUsersArray })
+                }
+              >
+                Remove IAM Users
+              </button>
+            </div>
+          </div>
+          {status?.isSuccess === false && (
+            <EagerErrorBoundary
+              message="Something went wrong fetching release data."
+              error={status.error}
+              styling="mt-5 shadow sm:rounded-md bg-red-100"
+            />
+          )}
+          {status === "working" && (
+            <div className="mt-5 bg-yellow-200 p-5 text-yellow-700 shadow sm:rounded-md">
+              Working...
+            </div>
+          )}
+          {status?.recordsUpdated !== undefined &&
+            status?.recordsUpdated === 0 && (
+              <div className="mt-5 bg-yellow-200 p-5 text-yellow-700 shadow sm:rounded-md">
+                The operation completed successfully but no objects were
+                updated. Make sure to select the cases which you would like to
+                be included in the release. Also make sure to enter IAM users
+                who the release should be made accessible to.
+              </div>
+            )}
+          {status?.recordsUpdated !== undefined &&
+            status?.recordsUpdated > 0 && (
+              <div className="mt-5 bg-green-200 p-5 text-green-700 shadow sm:rounded-md">
+                Successfully updated ACLs for {status?.recordsUpdated} objects
+              </div>
+            )}
+        </form>
+        {/* TODO: Implement me */}
+        {/* we use a POST form action here (rather than a onSubmit handler) because
+            form POSTS will be converted natively into a browser file save dialog
+             when the POST returned a Content-Disposition header */}
+        <form
+          action={`/api/releases/${releaseId}/gcp-storage/manifest`}
+          method="POST"
+          className="flex flex-col gap-4 p-6"
+        >
+          <label className="prose block">
+            The functionality from the perspective of a researcher.
+          </label>
+          {tsvColumnCheck("fileType")}
+          {tsvColumnCheck("patientId")}
+          {tsvColumnCheck("gsUrl")}
+          {tsvColumnCheck("md5")}
+          <input type="submit" className="btn-normal" value="Download TSV" />
+        </form>
+      </div>
+    </>
+  );
+};

--- a/application/frontend/src/pages/releases/detail/releases-detail-page.tsx
+++ b/application/frontend/src/pages/releases/detail/releases-detail-page.tsx
@@ -19,6 +19,7 @@ import { usePageSizer } from "../../../hooks/page-sizer";
 import { MasterAccessControlBox } from "./master-access-control-box";
 import { LogsBox } from "./logs-box/logs-box";
 import { AwsS3VpcShareForm } from "./aws-s3-vpc-share-form";
+import { GcpStorageIamShareForm } from "./gcp-storage-iam-share-form";
 import { HtsgetForm } from "./htsget-form";
 import DataAccessSummaryBox from "./logs-box/data-access-summary";
 import { ReleaseTypeLocal } from "./shared-types";
@@ -166,6 +167,7 @@ export const ReleasesDetailPage: React.FC = () => {
                   "Manifest",
                   "Presigned URL",
                   "AWS S3 VPC Share",
+                  "GCP Storage IAM Share",
                   "htsget",
                 ]}
               >
@@ -187,6 +189,7 @@ export const ReleasesDetailPage: React.FC = () => {
                   releaseData={releaseQuery.data}
                 />
                 <AwsS3VpcShareForm releaseId={releaseId} />
+                <GcpStorageIamShareForm releaseId={releaseId} />
                 <HtsgetForm
                   releaseId={releaseId}
                   releaseData={releaseQuery.data}


### PR DESCRIPTION
This feature lets users share Google Storage objects with anyone who has a gmail account. Demo:

[simplescreenrecorder-2023-02-17_11.19.46.webm](https://user-images.githubusercontent.com/11529449/219518297-17daec8a-19e2-4b6d-93c2-95cc18403045.webm)

This solution sucks because permissions aren't applied transactionally. If someone enters a mixture of IAM principals which do and don't exist, then applying permissions will fail and (almost surely) be partially applied. Automatic rollbacks are impossible in that case because you don't know which ACLs were added by Elsa. The proper solution would have been to create an IAM group for each release, and link users to objects using those groups. Unfortunately, Google requires you to subscribe to Google Identity or Google Workspace to programmatically create and modify groups. Hence, this PR.

Another thing to note is that I haven't hooked up the UI components to generate a TSV manifest in this PR. My initial thought was that I could annotate objects with metadata indicating their presence in a release then search for the annotated objects. Unfortunately, GCP doesn't provide a way to search for objects. We'd need to download a list of objects in the release then query their metadata one-by-one to determine their membership. IMO a much better solution would be to use the extensions to the release service (which started in #186 and keep track of objects in a release) to generate the TSVs. That part of the release service seems like a work in progress, so I'll follow up on TSV generation in a later PR.