### PR TITLE
Relay through and display build info

### DIFF
--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -92,14 +92,18 @@ RUN : \
   && npm run build:prod
 
 # we want to embed into the image environment immutable tags passed in by the build environment
+
+# this is the 'semantic' version as set by developers i.e. 1.0.3
 ARG ELSA_DATA_VERSION
 RUN ["/bin/bash", "-c", ": ${ELSA_DATA_VERSION:?Build argument needs to be set and not null.}"]
 ENV ELSA_DATA_VERSION $ELSA_DATA_VERSION
 
+# this is the literal timestamp of building
 ARG ELSA_DATA_BUILT
 RUN ["/bin/bash", "-c", ": ${ELSA_DATA_BUILT:?Build argument needs to be set and not null.}"]
 ENV ELSA_DATA_BUILT $ELSA_DATA_BUILT
 
+# this is the github revision tag that precisely indicates the commit trigger
 ARG ELSA_DATA_REVISION
 RUN ["/bin/bash", "-c", ": ${ELSA_DATA_REVISION:?Build argument needs to be set and not null.}"]
 ENV ELSA_DATA_REVISION $ELSA_DATA_REVISION

--- a/application/backend/.env.aws
+++ b/application/backend/.env.aws
@@ -10,4 +10,8 @@
 # for any cloud/cluster/docker deployment it is expected that the deployment will set the environment variables and
 # so this .env.* file *is not used*
 
+ELSA_DATA_VERSION=local-dev-aws
+ELSA_DATA_BUILT=sometime
+ELSA_DATA_REVISION=0000000000000000000000000000000000000000
+
 ELSA_DATA_META_CONFIG_SOURCES="file('base') file('dev-common') file('dev-localhost') file('datasets') aws-secret('ElsaDataLocalhost')"

--- a/application/backend/.env.linux
+++ b/application/backend/.env.linux
@@ -10,4 +10,8 @@
 # for any cloud/cluster/docker deployment it is expected that the deployment will set the environment variables and
 # so this .env.* file *is not used*
 
+ELSA_DATA_VERSION=local-dev-linux
+ELSA_DATA_BUILT=sometime
+ELSA_DATA_REVISION=0000000000000000000000000000000000000000
+
 ELSA_DATA_META_CONFIG_SOURCES="file('base') file('dev-common') file('dev-localhost') file('datasets') linux-pass('elsa-data')"

--- a/application/backend/.env.mac
+++ b/application/backend/.env.mac
@@ -10,4 +10,8 @@
 # for any cloud/cluster/docker deployment it is expected that the deployment will set the environment variables and
 # so this .env.* file *is not used*
 
+ELSA_DATA_VERSION=local-dev-mac
+ELSA_DATA_BUILT=sometime
+ELSA_DATA_REVISION=0000000000000000000000000000000000000000
+
 ELSA_DATA_META_CONFIG_SOURCES="file('base') file('dev-common') file('dev-localhost') file('datasets') osx-keychain('elsa-data')"

--- a/application/backend/src/app-env.ts
+++ b/application/backend/src/app-env.ts
@@ -1,3 +1,11 @@
+/**
+ * The following are the items that are passed through to the
+ * compiler of the index.html template.
+ */
+export type IndexHtmlTemplateData = {
+  data_attributes: string;
+};
+
 export function getMandatoryEnv(name: string): string {
   const val = process.env[name];
 

--- a/application/frontend/src/index.tsx
+++ b/application/frontend/src/index.tsx
@@ -20,18 +20,18 @@ if (rootElement != null) {
   // React code
   // the pattern we use is that when the index page is served up by the server - it uses templating to set
   // a variety of data attributes on the rootElement DOM node
-  //      data-semantic-version="1.2.3"
+  //      data-deployed-environment="production"
   // in the index.html that goes to the client
-  // in the react this then comes into the rootElement element as a dataset (via HTML5 standard behaviour)
+  // in the react this then comes into the rootElement element as a dataset (via HTML5 native behaviour)
   // e.g.
-  // rootElement.dataset.semanticVersion
+  // rootElement.dataset.deployedEnvironment
   // (NOTE: the conversion from kebab casing to camel casing is AUTOMATIC as part of HTML5!)
   const loc = rootElement.dataset.locale || "en";
-  const sv = rootElement.dataset.semanticVersion || "undefined version";
-  const bv = rootElement.dataset.buildVersion || "-1";
+  const ver = rootElement.dataset.version || "undefined version";
+  const built = rootElement.dataset.built || "unknown";
+  const rev = rootElement.dataset.revision || "undefined revision";
   const de = (rootElement.dataset.deployedEnvironment ||
     "development") as DeployedEnvironments;
-  const dl = rootElement.dataset.deployedLocation || "undefined location";
   const tfu =
     rootElement.dataset.terminologyFhirUrl || "undefined terminology FHIR URL";
 
@@ -43,10 +43,10 @@ if (rootElement != null) {
       <ErrorBoundary rethrowError={(_: any) => false}>
         {/* the env relay converts the backend index.html info into strongly typed values accessible throughout */}
         <EnvRelayProvider
-          semanticVersion={sv}
-          buildVersion={bv}
+          version={ver}
+          built={built}
+          revision={rev}
           deployedEnvironment={de}
-          deployedLocation={dl}
           terminologyFhirUrl={tfu}
         >
           {/* the query provider comes from react-query and provides standardised remote query semantics */}

--- a/application/frontend/src/layouts/layout-base-footer.tsx
+++ b/application/frontend/src/layouts/layout-base-footer.tsx
@@ -1,38 +1,36 @@
 import React from "react";
+import { useEnvRelay } from "../providers/env-relay-provider";
 
 export const LayoutBaseFooter: React.FC = () => {
+  const envRelay = useEnvRelay();
+
   return (
     <>
-      <footer className="border-t border-gray-400 bg-white shadow">
-        <div className="container mx-auto flex max-w-md py-2">
-          <div className="mx-auto flex w-full flex-wrap">
-            <div className="flex w-full md:w-1/2 ">
-              <div className="px-8">
-                <h3 className="font-bold font-bold text-gray-900">About</h3>
-                {/*<p className="py-4 text-gray-600 text-sm">
-                  A data release coordinator
-                </p> */}
-              </div>
-            </div>
+      <div className="container mx-auto w-full">
+        <footer className="p-4 dark:bg-gray-800 md:flex md:items-center md:justify-between md:p-6">
+          <span className="text-sm text-gray-500 dark:text-gray-400 sm:text-center">
+            Elsa Data
+            <span
+              className="mr-1 ml-3 text-gray-300"
+              title={envRelay.built + " " + envRelay.revision}
+            >
+              v
+            </span>
+            {envRelay.version}
+          </span>
+          <ul className="mt-3 flex flex-wrap items-center text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
+            <li>
+              <a
+                href="https://github.com/umccr/elsa-data"
+                className="hover:underline"
+              >
+                Github
+              </a>
+            </li>
+          </ul>
+        </footer>
+      </div>
 
-            <div className="flex w-full md:w-1/2">
-              <div className="px-8">
-                <h3 className="font-bold font-bold text-gray-900">Social</h3>
-                {/*<ul className="list-reset items-center text-sm pt-3">
-                  <li>
-                    <a
-                      className="inline-block text-gray-600 no-underline hover:text-gray-900 hover:underline py-1"
-                      href="https://www.ga4gh.org"
-                    >
-                      GA4GH
-                    </a>
-                  </li>
-                </ul> */}
-              </div>
-            </div>
-          </div>
-        </div>
-      </footer>
       {/* FOOTER END */}
     </>
   );

--- a/application/frontend/src/layouts/layout-base.tsx
+++ b/application/frontend/src/layouts/layout-base.tsx
@@ -3,6 +3,7 @@ import { NavLink } from "react-router-dom";
 import { useLoggedInUser } from "../providers/logged-in-user-provider";
 import { LayoutBaseHeaderUser } from "./layout-base-header-user";
 import { ErrorBoundary } from "../components/errors";
+import { LayoutBaseFooter } from "./layout-base-footer";
 
 type Props = {};
 
@@ -166,7 +167,7 @@ export const LayoutBase: React.FC<PropsWithChildren<Props>> = ({
         </div>
       </div>
 
-      {/*<LayoutBaseFooter />*/}
+      <div className="bg-white">{<LayoutBaseFooter />}</div>
     </>
   );
 };

--- a/application/frontend/src/providers/env-relay-provider.tsx
+++ b/application/frontend/src/providers/env-relay-provider.tsx
@@ -4,10 +4,28 @@ import { createCtx } from "./create-ctx";
 export type DeployedEnvironments = "production" | "development";
 
 export type EnvRelay = {
-  semanticVersion: string;
-  buildVersion: string;
+  /**
+   * The version of this released software. e.g. 1.0.1
+   * Though this string should only be used by the front end for
+   * display purposes - there is no guarantee that it will always
+   * be strictly a semantic version for instance.
+   */
+  version: string;
+
+  /**
+   * The ISO date time of the building of this release software,
+   * though this string should only be used by the front end for
+   * display purposes - there is no guarantee that it is an ISO
+   * parseable time.
+   */
+  built: string;
+
+  /**
+   * The precise source revision used for building this software.
+   */
+  revision: string;
+
   deployedEnvironment: DeployedEnvironments;
-  deployedLocation: string;
   terminologyFhirUrl: string;
 };
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -68,6 +68,9 @@ const config: PlaywrightTestConfig = {
     env: {
       DEBUG: "pw:webserver",
       NODE_ENV: "development",
+      ELSA_DATA_VERSION: "e2e",
+      ELSA_DATA_BUILT: "now",
+      ELSA_DATA_REVISION: "abcd",
       ELSA_DATA_META_CONFIG_SOURCES: "file('e2e')",
       ELSA_DATA_META_CONFIG_FOLDERS: resolve("config"),
     },


### PR DESCRIPTION
The env variables we fill in during the docker build can be brought through to the UI - for easy support requests as the users can report the specific build they are using
