### PR TITLE
`releaseIdentifier` vs `releaseUUID`

### DIFF
--- a/application/backend/config/base.json5
+++ b/application/backend/config/base.json5
@@ -2,4 +2,5 @@
   // an ontoserver with MONDO terminology loaded
   ontoFhirUrl: "https://onto.prod.umccr.org/fhir",
   maxmindDbAssetPath: "asset/maxmind/db/",
+  releaseIdPrefix: "R",
 }

--- a/application/backend/dbschema/queries/release-participation/releaseParticipantAddPotentialUser.edgeql
+++ b/application/backend/dbschema/queries/release-participation/releaseParticipantAddPotentialUser.edgeql
@@ -5,6 +5,6 @@ update permission::PotentialUser
 filter .id = <uuid>$potentialUserUuid
 set {
  futureReleaseParticipant += (
-    select release::Release { @role := <str>$role } filter .id = <uuid>$releaseUuid
+    select release::Release { @role := <str>$role } filter .releaseIdentifier = <str>$releaseId
     )
 };

--- a/application/backend/dbschema/queries/release-participation/releaseParticipantAddUser.edgeql
+++ b/application/backend/dbschema/queries/release-participation/releaseParticipantAddUser.edgeql
@@ -5,6 +5,6 @@ update permission::User
 filter .id = <uuid>$userUuid
 set {
  releaseParticipant += (
-    select release::Release { @role := <str>$role } filter .id = <uuid>$releaseUuid
+    select release::Release { @role := <str>$role } filter .releaseIdentifier = <str>$releaseId
     )
 };

--- a/application/backend/dbschema/queries/release-participation/releaseParticipantGetAll.edgeql
+++ b/application/backend/dbschema/queries/release-participation/releaseParticipantGetAll.edgeql
@@ -16,8 +16,8 @@ with
       email,
       displayName,
       lastLoginDateTime,
-      releaseParticipant: { @role } filter .id = <uuid>$releaseUuid
-    } filter .releaseParticipant.id =  <uuid>$releaseUuid),
+      releaseParticipant: { @role } filter .releaseIdentifier = <str>$releaseId
+    } filter .releaseParticipant.releaseIdentifier =  <str>$releaseId),
 
   # potential users have been mentioned for a release but have not yet logged in
   pu := (
@@ -25,8 +25,8 @@ with
       id,
       email,
       displayName,
-      futureReleaseParticipant: { @role } filter .id = <uuid>$releaseUuid
-    } filter .futureReleaseParticipant.id =  <uuid>$releaseUuid)
+      futureReleaseParticipant: { @role } filter .releaseIdentifier = <str>$releaseId
+    } filter .futureReleaseParticipant.releaseIdentifier =  <str>$releaseId)
 
 select
   # merge the users and potential users into a single set

--- a/application/backend/dbschema/queries/release-participation/releaseParticipantRemovePotentialUser.edgeql
+++ b/application/backend/dbschema/queries/release-participation/releaseParticipantRemovePotentialUser.edgeql
@@ -5,6 +5,6 @@ update permission::PotentialUser
 filter .id = <uuid>$potentialUserUuid
 set {
  futureReleaseParticipant -= (
-    select release::Release filter .id = <uuid>$releaseUuid
+    select release::Release filter .releaseIdentifier = <str>$releaseId
     )
 };

--- a/application/backend/dbschema/queries/release-participation/releaseParticipantRemoveUser.edgeql
+++ b/application/backend/dbschema/queries/release-participation/releaseParticipantRemoveUser.edgeql
@@ -5,6 +5,6 @@ update permission::User
 filter .id = <uuid>$userUuid
 set {
  releaseParticipant -= (
-    select release::Release filter .id = <uuid>$releaseUuid
+    select release::Release filter .releaseIdentifier = <str>$releaseId
     )
 };

--- a/application/backend/src/api/routes/internal/release-routes.ts
+++ b/application/backend/src/api/routes/internal/release-routes.ts
@@ -145,12 +145,12 @@ export const releaseRoutes = async (fastify: FastifyInstance) => {
     async function (request, reply) {
       const { authenticatedUser } = authenticatedRouteOnEntryHelper(request);
 
-      const releaseUuid = request.params.rid;
+      const releaseId = request.params.rid;
       const participantUuid = request.params.pid;
 
       return releaseParticipantService.removeParticipant(
         authenticatedUser,
-        releaseUuid,
+        releaseId,
         participantUuid
       );
     }

--- a/application/backend/src/bootstrap-settings.ts
+++ b/application/backend/src/bootstrap-settings.ts
@@ -96,6 +96,7 @@ export async function bootstrapSettings(config: any): Promise<ElsaSettings> {
     },
     ontoFhirUrl: config.get("ontoFhirUrl"),
     maxmindDbAssetPath: config.get("maxmindDbAssetPath"),
+    releaseIdPrefix: config.get("releaseIdPrefix"),
     mondoSystem: {
       uri: config.get("mondoSystem.uri"),
       oid: config.get("mondoSystem.oid"),

--- a/application/backend/src/business/db/audit-log-queries.ts
+++ b/application/backend/src/business/db/audit-log-queries.ts
@@ -14,12 +14,12 @@ export const countAuditLogEntriesForSystemQuery = e.count(
  */
 export const countAuditLogEntriesForReleaseQuery = e.params(
   {
-    releaseId: e.uuid,
+    releaseId: e.str,
   },
   (params) =>
     e.count(
       e.select(e.audit.ReleaseAuditEvent, (ae) => ({
-        filter: e.op(ae.release_.id, "=", params.releaseId),
+        filter: e.op(ae.release_.releaseIdentifier, "=", params.releaseId),
       }))
     )
 );
@@ -30,12 +30,12 @@ export const countAuditLogEntriesForReleaseQuery = e.params(
  */
 export const countDataAccessAuditLogEntriesQuery = e.params(
   {
-    releaseId: e.uuid,
+    releaseId: e.str,
   },
   (params) =>
     e.count(
       e.select(e.audit.DataAccessAuditEvent, (da) => ({
-        filter: e.op(da.release_.id, "=", params.releaseId),
+        filter: e.op(da.release_.releaseIdentifier, "=", params.releaseId),
       }))
     )
 );
@@ -91,7 +91,7 @@ export const pageableAuditLogEntriesForReleaseQuery = (
     occurredDuration: true,
     outcome: true,
     hasDetails: e.op("exists", auditEvent.details),
-    filter: e.op(auditEvent.release_.id, "=", e.uuid(releaseId)),
+    filter: e.op(auditEvent.release_.releaseIdentifier, "=", releaseId),
     order_by: [
       {
         expression:
@@ -139,7 +139,7 @@ export const selectDataAccessAuditEventByReleaseIdQuery = (
     ...e.audit.DataAccessAuditEvent["*"],
     fileSize: da.details.size,
     fileUrl: da.details.url,
-    filter: e.op(da.release_.id, "=", e.uuid(releaseId)),
+    filter: e.op(da.release_.releaseIdentifier, "=", releaseId),
     order_by: [
       {
         expression:

--- a/application/backend/src/business/db/release-queries.ts
+++ b/application/backend/src/business/db/release-queries.ts
@@ -42,11 +42,11 @@ export const allReleasesSummaryByUserQuery = e.params(
  */
 export const touchRelease = e.params(
   {
-    releaseId: e.uuid,
+    releaseId: e.str,
   },
   (params) =>
     e.update(e.release.Release, (r) => ({
-      filter: e.op(r.id, "=", params.releaseId),
+      filter: e.op(r.releaseIdentifier, "=", params.releaseId),
       set: { lastUpdated: e.datetime_current() },
     }))
 );

--- a/application/backend/src/business/db/release-queries.ts
+++ b/application/backend/src/business/db/release-queries.ts
@@ -50,3 +50,25 @@ export const touchRelease = e.params(
       set: { lastUpdated: e.datetime_current() },
     }))
 );
+
+/**
+ * Find the next release identifier based on release count.
+ * @param prefix The prefix id before the release count.
+ * @returns
+ */
+export const getNextReleaseId = (prefix: string = "R") => {
+  const minDigitLength = 3;
+
+  const nextIdString = e.to_str(e.op(e.count(e.release.Release), "+", 1));
+
+  // Formatting string to add leading 0s if len(nextId) < minDigitLength
+  const formatIdString = e.op(
+    e.str_pad_start(nextIdString, minDigitLength, "0"),
+    "if",
+    e.op(e.len(nextIdString), "<=", minDigitLength),
+    "else",
+    nextIdString
+  );
+
+  return e.op(e.str(prefix), "++", formatIdString);
+};

--- a/application/backend/src/business/db/release-queries.ts
+++ b/application/backend/src/business/db/release-queries.ts
@@ -27,7 +27,7 @@ export const allReleasesSummaryByUserQuery = e.params(
         // as release identifier is essentially a meaningless random string
         order_by: {
           expression: rp.releaseIdentifier,
-          direction: e.ASC,
+          direction: e.DESC,
         },
         limit: params.limit,
         offset: params.offset,

--- a/application/backend/src/business/db/user-queries.ts
+++ b/application/backend/src/business/db/user-queries.ts
@@ -97,14 +97,14 @@ export const pageableAllUserQuery = e.params(
  * Add the user as a participant in a release with the given role.
  */
 export const addUserToReleaseWithRole = e.params(
-  { releaseId: e.uuid, userDbId: e.uuid, role: e.str },
+  { releaseUuid: e.uuid, userDbId: e.uuid, role: e.str },
   (params) =>
     e.update(e.permission.User, (u) => ({
       filter: e.op(params.userDbId, "=", u.id),
       set: {
         releaseParticipant: {
           "+=": e.select(e.release.Release, (r) => ({
-            filter: e.op(params.releaseId, "=", r.id),
+            filter: e.op(params.releaseUuid, "=", r.id),
             "@role": params.role,
           })),
         },

--- a/application/backend/src/business/services/audit-log-service.ts
+++ b/application/backend/src/business/services/audit-log-service.ts
@@ -90,7 +90,7 @@ export class AuditLogService {
     // the id of the newly inserted event (instead we can only get the release id)
     await e
       .update(e.release.Release, (r) => ({
-        filter: e.op(e.uuid(releaseId), "=", r.id),
+        filter: e.op(releaseId, "=", r.releaseIdentifier),
         set: {
           releaseAuditLog: {
             "+=": e.select(e.audit.ReleaseAuditEvent, (ae) => ({
@@ -174,7 +174,7 @@ export class AuditLogService {
 
     await e
       .update(e.release.Release, (r) => ({
-        filter: e.op(r.id, "=", e.uuid(releaseId)),
+        filter: e.op(r.releaseIdentifier, "=", releaseId),
         set: {
           dataAccessAuditLog: {
             "+=": e.insert(e.audit.DataAccessAuditEvent, {

--- a/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
+++ b/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
@@ -272,7 +272,7 @@ ${roleTable.join("\n")}
           isAllowedReadData: false,
           isAllowedVariantData: false,
           isAllowedPhenotypeData: false,
-          releaseIdentifier: getNextReleaseId(),
+          releaseIdentifier: getNextReleaseId(this.settings.releaseIdPrefix),
           // for the moment we fix this to a known secret
           releasePassword: "abcd",
           datasetUris: e.literal(

--- a/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
+++ b/application/backend/src/business/services/australian-genomics/redcap-import-application-service.ts
@@ -18,6 +18,7 @@ import {
 } from "../../db/user-queries";
 import { generate } from "randomstring";
 import _ from "lodash";
+import { getNextReleaseId } from "../../db/release-queries";
 
 // we should make this a sensible stable system for the application ids out of Australian Genomics
 const AG_REDCAP_URL = "https://redcap.mcri.edu.au";
@@ -271,12 +272,7 @@ ${roleTable.join("\n")}
           isAllowedReadData: false,
           isAllowedVariantData: false,
           isAllowedPhenotypeData: false,
-          releaseIdentifier: generate({
-            length: 10,
-            capitalization: "uppercase",
-            charset: "alphabetic",
-            readable: true,
-          }),
+          releaseIdentifier: getNextReleaseId(),
           // for the moment we fix this to a known secret
           releasePassword: "abcd",
           datasetUris: e.literal(

--- a/application/backend/src/business/services/aws-cloudtrail-lake-service.ts
+++ b/application/backend/src/business/services/aws-cloudtrail-lake-service.ts
@@ -72,7 +72,7 @@ export class AwsCloudTrailLakeService extends AwsBaseService {
       .select(e.release.Release, (r) => ({
         created: true,
         lastDateTimeDataAccessLogQuery: true,
-        filter: e.op(r.id, "=", e.uuid(releaseId)),
+        filter: e.op(r.releaseIdentifier, "=", releaseId),
       }))
       .assert_single()
       .run(this.edgeDbClient);
@@ -356,7 +356,7 @@ export class AwsCloudTrailLakeService extends AwsBaseService {
     // Update last query date to release record
     await e
       .update(e.release.Release, (r) => ({
-        filter: e.op(r.id, "=", e.uuid(releaseId)),
+        filter: e.op(r.releaseIdentifier, "=", releaseId),
         set: {
           lastDateTimeDataAccessLogQuery: e.datetime(endQueryDate),
         },

--- a/application/backend/src/business/services/dataset-service.ts
+++ b/application/backend/src/business/services/dataset-service.ts
@@ -45,7 +45,7 @@ export class DatasetService {
     return (
       await e
         .select(e.release.Release, (r) => ({
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
           datasetUris: true,
         }))
         .assert_single()

--- a/application/backend/src/business/services/helpers.ts
+++ b/application/backend/src/business/services/helpers.ts
@@ -54,7 +54,7 @@ export async function getReleaseInfo(
   // the base (id only) query that will give us just the release
   const releaseQuery = e
     .select(e.release.Release, (r) => ({
-      filter: e.op(r.id, "=", e.uuid(releaseId)),
+      filter: e.op(r.releaseIdentifier, "=", releaseId),
     }))
     .assert_single();
 

--- a/application/backend/src/business/services/jobs/jobs-base-service.ts
+++ b/application/backend/src/business/services/jobs/jobs-base-service.ts
@@ -68,7 +68,7 @@ export class JobsService {
           filter: e.op(
             e.op(j.status, "=", e.job.JobStatus.running),
             "and",
-            e.op(j.forRelease.id, "=", e.uuid(releaseId))
+            e.op(j.forRelease.releaseIdentifier, "=", releaseId)
           ),
         }))
         .run(tx);
@@ -95,7 +95,7 @@ export class JobsService {
       .select(e.job.Job, (j) => ({
         __type__: { name: true },
         id: true,
-        forRelease: { id: true },
+        forRelease: { id: true, releaseIdentifier: true },
         requestedCancellation: true,
         auditEntry: true,
         started: true,
@@ -111,7 +111,7 @@ export class JobsService {
         return {
           jobId: j.id,
           jobType: typeName.substring("job::".length),
-          releaseId: j.forRelease.id,
+          releaseId: j.forRelease.releaseIdentifier,
           auditEntryId: j.auditEntry.id,
           auditEntryStarted: j.started,
           requestedCancellation: j.requestedCancellation,
@@ -351,7 +351,7 @@ export class JobsService {
           filter: e.op(
             e.op(j.status, "=", e.job.JobStatus.running),
             "and",
-            e.op(j.forRelease.id, "=", e.uuid(releaseId))
+            e.op(j.forRelease.releaseIdentifier, "=", releaseId)
           ),
         }))
         .assert_single()
@@ -680,7 +680,7 @@ export class JobsService {
         filter: e.op(
           e.op(sj.status, "!=", e.job.JobStatus.running),
           "and",
-          e.op(sj.forRelease.id, "=", e.uuid(releaseId))
+          e.op(sj.forRelease.releaseIdentifier, "=", releaseId)
         ),
       }))
       .run(this.edgeDbClient);

--- a/application/backend/src/business/services/manifests/manifest-service.ts
+++ b/application/backend/src/business/services/manifests/manifest-service.ts
@@ -18,21 +18,13 @@ export class ManifestService {
   public async getActiveManifest(
     releaseId: string
   ): Promise<ManifestType | null> {
-    // whilst we are sorting out what exactly our release id should be - this
-    // is a simple boundary check that the format is ok according to edgedb
-    try {
-      await e.uuid(releaseId).run(this.edgeDbClient);
-    } catch (e) {
-      return null;
-    }
-
     const releaseWithManifest = await e
       .select(e.release.Release, (r) => ({
         id: true,
         activation: {
           manifest: true,
         },
-        filter: e.op(r.id, "=", e.uuid(releaseId)),
+        filter: e.op(r.releaseIdentifier, "=", releaseId),
       }))
       .assert_single()
       .run(this.edgeDbClient);

--- a/application/backend/src/business/services/release-base-service.ts
+++ b/application/backend/src/business/services/release-base-service.ts
@@ -54,7 +54,7 @@ export abstract class ReleaseBaseService {
   protected baseQueriesForSingleRelease(releaseId: string) {
     const releaseQuery = e
       .select(e.release.Release, (r) => ({
-        filter: e.op(r.id, "=", e.uuid(releaseId)),
+        filter: e.op(r.releaseIdentifier, "=", (releaseId)),
       }))
       .assert_single();
 
@@ -242,7 +242,7 @@ export abstract class ReleaseBaseService {
       // add specimens to the selected set
       await e
         .update(e.release.Release, (r) => ({
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
           set: {
             selectedSpecimens: { "+=": specimensFromValidDatasetsQuery },
           },
@@ -252,7 +252,7 @@ export abstract class ReleaseBaseService {
       // remove specimens from the selected set
       await e
         .update(e.release.Release, (r) => ({
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
           set: {
             selectedSpecimens: { "-=": specimensFromValidDatasetsQuery },
           },
@@ -306,7 +306,7 @@ export abstract class ReleaseBaseService {
             countriesInvolved: true,
             diseasesOfStudy: true,
           },
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
         }))
         .assert_single()
         .run(tx);

--- a/application/backend/src/business/services/release-service.ts
+++ b/application/backend/src/business/services/release-service.ts
@@ -26,6 +26,7 @@ import { UsersService } from "./users-service";
 import { ReleaseBaseService } from "./release-base-service";
 import {
   allReleasesSummaryByUserQuery,
+  getNextReleaseId,
   touchRelease,
 } from "../db/release-queries";
 import { $DatasetCase } from "../../../dbschema/edgeql-js/modules/dataset";
@@ -117,7 +118,7 @@ export class ReleaseService extends ReleaseBaseService {
     user: AuthenticatedUser,
     release: ReleaseManualType
   ): Promise<string> {
-    const releaseIdentifier = randomUUID();
+    const releaseIdentifier = getNextReleaseId();
 
     const releaseRow = await e
       .insert(e.release.Release, {

--- a/application/backend/src/business/services/release-service.ts
+++ b/application/backend/src/business/services/release-service.ts
@@ -664,7 +664,7 @@ ${release.applicantEmailAddresses}
             countriesInvolved: true,
             diseasesOfStudy: true,
           },
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
         }))
         .assert_single()
         .run(tx);
@@ -706,7 +706,7 @@ ${release.applicantEmailAddresses}
       const releaseWithAppCoded = await e
         .select(e.release.Release, (r) => ({
           applicationCoded: true,
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
         }))
         .assert_single()
         .run(tx);
@@ -766,7 +766,7 @@ ${release.applicantEmailAddresses}
     await this.edgeDbClient.transaction(async (tx) => {
       await e
         .update(e.release.Release, (r) => ({
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
           set: fieldToSet,
         }))
         .run(tx);
@@ -814,7 +814,7 @@ ${release.applicantEmailAddresses}
 
       await e
         .update(e.release.Release, (r) => ({
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
           set: {
             activation: e.insert(e.release.Activation, {
               activatedById: user.subjectId,
@@ -851,7 +851,7 @@ ${release.applicantEmailAddresses}
 
       await e
         .update(e.release.Release, (r) => ({
-          filter: e.op(r.id, "=", e.uuid(releaseId)),
+          filter: e.op(r.releaseIdentifier, "=", releaseId),
           set: {
             previouslyActivated: { "+=": r.activation },
             activation: null,

--- a/application/backend/src/business/services/release-service.ts
+++ b/application/backend/src/business/services/release-service.ts
@@ -118,7 +118,7 @@ export class ReleaseService extends ReleaseBaseService {
     user: AuthenticatedUser,
     release: ReleaseManualType
   ): Promise<string> {
-    const releaseIdentifier = getNextReleaseId();
+    const releaseIdentifier = getNextReleaseId(this.settings.releaseIdPrefix);
 
     const releaseRow = await e
       .insert(e.release.Release, {

--- a/application/backend/src/business/services/rems-service.ts
+++ b/application/backend/src/business/services/rems-service.ts
@@ -186,7 +186,7 @@ ${JSON.stringify(application["application/applicant"], null, 2)}
           datasetIndividualUrisOrderPreference: [""],
           datasetSpecimenUrisOrderPreference: [""],
           datasetCaseUrisOrderPreference: [""],
-          releaseIdentifier: getNextReleaseId(),
+          releaseIdentifier: getNextReleaseId(this.settings.releaseIdPrefix),
           releasePassword: randomUUID(),
           datasetUris: e.literal(
             e.array(e.str),

--- a/application/backend/src/business/services/rems-service.ts
+++ b/application/backend/src/business/services/rems-service.ts
@@ -10,6 +10,7 @@ import { AuthenticatedUser } from "../authenticated-user";
 import { isEmpty } from "lodash";
 import { ElsaSettings } from "../../config/elsa-settings";
 import { format } from "date-fns";
+import { getNextReleaseId } from "../db/release-queries";
 
 @injectable()
 @singleton()
@@ -185,7 +186,7 @@ ${JSON.stringify(application["application/applicant"], null, 2)}
           datasetIndividualUrisOrderPreference: [""],
           datasetSpecimenUrisOrderPreference: [""],
           datasetCaseUrisOrderPreference: [""],
-          releaseIdentifier: randomUUID(),
+          releaseIdentifier: getNextReleaseId(),
           releasePassword: randomUUID(),
           datasetUris: e.literal(
             e.array(e.str),

--- a/application/backend/src/business/services/users-service.ts
+++ b/application/backend/src/business/services/users-service.ts
@@ -178,7 +178,7 @@ export class UsersService {
    */
   public async registerRoleInRelease(
     user: AuthenticatedUser,
-    releaseId: string,
+    releaseUuid: string,
     role: ReleaseRoleStrings
   ) {
     await e
@@ -187,7 +187,7 @@ export class UsersService {
         set: {
           releaseParticipant: {
             "+=": e.select(e.release.Release, (r) => ({
-              filter: e.op(e.uuid(releaseId), "=", r.id),
+              filter: e.op(e.uuid(releaseUuid), "=", r.id),
               "@role": e.str(role),
             })),
           },
@@ -217,7 +217,7 @@ export class UsersService {
         releaseParticipant: (rp) => ({
           id: true,
           "@role": true,
-          filter: e.op(rp.id, "=", e.uuid(releaseId)),
+          filter: e.op(rp.releaseIdentifier, "=", releaseId),
         }),
         filter: e.op(e.str(user.subjectId), "=", u.subjectId),
       }))

--- a/application/backend/src/config/config-constants.ts
+++ b/application/backend/src/config/config-constants.ts
@@ -143,6 +143,11 @@ export const configDefinition = {
     format: "*",
     default: "asset/maxmind/db/",
   },
+  releaseIdPrefix: {
+    doc: "The prefix appended on the releaseId before the count number.",
+    format: "*",
+    default: "R",
+  },
   mondoSystem: {
     uri: {
       format: String,

--- a/application/backend/src/config/elsa-settings.ts
+++ b/application/backend/src/config/elsa-settings.ts
@@ -47,6 +47,9 @@ export type ElsaSettings = {
   // maxmind database for IP Geo lookup
   maxmindDbAssetPath: string;
 
+  // prefix for releaseId
+  releaseIdPrefix: string;
+
   // NOTE: https://confluence.hl7.org/display/TA/External+Terminologies+-+Information is a good reference for these
   mondoSystem: { uri: string; oid: string };
   hgncGenesSystem: { uri: string; oid: string };

--- a/application/backend/src/test-data/insert-test-data-release1.ts
+++ b/application/backend/src/test-data/insert-test-data-release1.ts
@@ -87,7 +87,7 @@ Ethics form XYZ.
       // B5MN76L3BN
       //
       //
-      releaseIdentifier: getNextReleaseId(),
+      releaseIdentifier: `R001`,
       activation: e.insert(e.release.Activation, {
         activatedAt: e.datetime(new Date(2022, 9, 12, 4, 2, 5)),
         activatedById: TEST_SUBJECT_2,

--- a/application/backend/src/test-data/insert-test-data-release1.ts
+++ b/application/backend/src/test-data/insert-test-data-release1.ts
@@ -28,6 +28,7 @@ import {
   TEST_SUBJECT_3,
   TEST_SUBJECT_3_DISPLAY,
 } from "./insert-test-users";
+import { getNextReleaseId } from "../business/db/release-queries";
 
 const edgeDbClient = edgedb.createClient();
 
@@ -86,7 +87,7 @@ Ethics form XYZ.
       // B5MN76L3BN
       //
       //
-      releaseIdentifier: "C5YR7P2PE1",
+      releaseIdentifier: getNextReleaseId(),
       activation: e.insert(e.release.Activation, {
         activatedAt: e.datetime(new Date(2022, 9, 12, 4, 2, 5)),
         activatedById: TEST_SUBJECT_2,

--- a/application/backend/src/test-data/insert-test-data-release2.ts
+++ b/application/backend/src/test-data/insert-test-data-release2.ts
@@ -27,7 +27,7 @@ export async function insertRelease2() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: getNextReleaseId(),
+      releaseIdentifier: "R002",
       releasePassword: "bbew75CZ", // pragma: allowlist secret
       isAllowedReadData: true,
       isAllowedVariantData: true,

--- a/application/backend/src/test-data/insert-test-data-release2.ts
+++ b/application/backend/src/test-data/insert-test-data-release2.ts
@@ -5,6 +5,7 @@ import {
   makeSystemlessIdentifier,
 } from "./test-data-helpers";
 import { TENF_URI } from "./insert-test-data-10f-helpers";
+import { getNextReleaseId } from "../business/db/release-queries";
 
 const edgeDbClient = edgedb.createClient();
 
@@ -26,7 +27,7 @@ export async function insertRelease2() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: "RH5WOR7QXB",
+      releaseIdentifier: getNextReleaseId(),
       releasePassword: "bbew75CZ", // pragma: allowlist secret
       isAllowedReadData: true,
       isAllowedVariantData: true,

--- a/application/backend/src/test-data/insert-test-data-release3.ts
+++ b/application/backend/src/test-data/insert-test-data-release3.ts
@@ -1,5 +1,6 @@
 import * as edgedb from "edgedb";
 import e from "../../dbschema/edgeql-js";
+import { getNextReleaseId } from "../business/db/release-queries";
 import {
   makeEmptyCodeArray,
   makeSystemlessIdentifier,
@@ -45,7 +46,7 @@ export async function insertRelease3() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: "P4RF4AC5BR",
+      releaseIdentifier: getNextReleaseId(),
       selectedSpecimens: e.set(),
       isAllowedReadData: true,
       isAllowedVariantData: true,

--- a/application/backend/src/test-data/insert-test-data-release3.ts
+++ b/application/backend/src/test-data/insert-test-data-release3.ts
@@ -46,7 +46,7 @@ export async function insertRelease3() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: getNextReleaseId(),
+      releaseIdentifier: "R003",
       selectedSpecimens: e.set(),
       isAllowedReadData: true,
       isAllowedVariantData: true,

--- a/application/backend/src/test-data/insert-test-data-release4.ts
+++ b/application/backend/src/test-data/insert-test-data-release4.ts
@@ -51,7 +51,7 @@ export async function insertRelease4() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: getNextReleaseId(),
+      releaseIdentifier: `R004`,
       releasePassword: "abcd", // pragma: allowlist secret
       selectedSpecimens: e.set(),
       isAllowedReadData: true,

--- a/application/backend/src/test-data/insert-test-data-release4.ts
+++ b/application/backend/src/test-data/insert-test-data-release4.ts
@@ -5,6 +5,7 @@ import {
   makeSystemlessIdentifier,
 } from "./test-data-helpers";
 import { TENG_URI } from "./insert-test-data-10g";
+import { getNextReleaseId } from "../business/db/release-queries";
 
 const edgeDbClient = edgedb.createClient();
 
@@ -50,7 +51,7 @@ export async function insertRelease4() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: "S9DT3Z9NMA",
+      releaseIdentifier: getNextReleaseId(),
       releasePassword: "abcd", // pragma: allowlist secret
       selectedSpecimens: e.set(),
       isAllowedReadData: true,

--- a/application/backend/src/test-data/insert-test-data-release5.ts
+++ b/application/backend/src/test-data/insert-test-data-release5.ts
@@ -5,6 +5,7 @@ import {
   makeSystemlessIdentifier,
 } from "./test-data-helpers";
 import { GS_URI } from "./insert-test-data-gs";
+import { getNextReleaseId } from "../business/db/release-queries";
 
 const edgeDbClient = edgedb.createClient();
 
@@ -50,7 +51,7 @@ export async function insertRelease5() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: "S9DT3Z9NMAGS",
+      releaseIdentifier: getNextReleaseId(),
       releasePassword: "abcd", // pragma: allowlist secret
       selectedSpecimens: e.set(),
       isAllowedReadData: true,

--- a/application/backend/src/test-data/insert-test-data-release5.ts
+++ b/application/backend/src/test-data/insert-test-data-release5.ts
@@ -51,7 +51,7 @@ export async function insertRelease5() {
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
-      releaseIdentifier: getNextReleaseId(),
+      releaseIdentifier: `R005`,
       releasePassword: "abcd", // pragma: allowlist secret
       selectedSpecimens: e.set(),
       isAllowedReadData: true,

--- a/application/backend/src/test-data/test-data-helpers.ts
+++ b/application/backend/src/test-data/test-data-helpers.ts
@@ -133,7 +133,7 @@ export async function createTestUser(
 
   // a helper to update the role this users has with a release
   const insertRole = async (
-    releaseId: string,
+    releaseUuid: string,
     role: "DataOwner" | "PI" | "Member"
   ) => {
     await e
@@ -142,7 +142,7 @@ export async function createTestUser(
         set: {
           releaseParticipant: {
             "+=": e.select(e.release.Release, (r) => ({
-              filter: e.op(e.uuid(releaseId), "=", r.id),
+              filter: e.op(e.uuid(releaseUuid), "=", r.id),
               "@role": e.str(role),
             })),
           },

--- a/application/backend/tests/db-tests/edgedb-release-queries.test.ts
+++ b/application/backend/tests/db-tests/edgedb-release-queries.test.ts
@@ -44,13 +44,13 @@ describe("edgedb release queries tests", () => {
     const testUserInsert = await createTestUser();
 
     await addUserToReleaseWithRole.run(edgeDbClient, {
-      releaseId: release2.id,
+      releaseUuid: release2.id,
       userDbId: testUserInsert.id,
       role: "PI",
     });
 
     await addUserToReleaseWithRole.run(edgeDbClient, {
-      releaseId: release3.id,
+      releaseUuid: release3.id,
       userDbId: testUserInsert.id,
       role: "DataOwner",
     });
@@ -70,7 +70,7 @@ describe("edgedb release queries tests", () => {
     {
       const a = result!.releaseParticipant[0];
 
-      expect(a.releaseIdentifier).toBe("R00003");
+      expect(a.releaseIdentifier).toBe("R003");
       expect(a.applicationDacTitle).toBe("An Invisible Study");
       expect(a["@role"]).toBe("DataOwner");
     }
@@ -78,7 +78,7 @@ describe("edgedb release queries tests", () => {
     {
       const b = result!.releaseParticipant[1];
 
-      expect(b.releaseIdentifier).toBe("R00002");
+      expect(b.releaseIdentifier).toBe("R002");
       expect(b.applicationDacTitle).toBe("A Better Study of Limited Test Data");
       expect(b["@role"]).toBe("PI");
     }
@@ -102,19 +102,19 @@ describe("edgedb release queries tests", () => {
     const testUserInsert = await createTestUser();
 
     await addUserToReleaseWithRole.run(edgeDbClient, {
-      releaseId: release2.id,
+      releaseUuid: release2.id,
       userDbId: testUserInsert.id,
       role: "PI",
     });
 
     await addUserToReleaseWithRole.run(edgeDbClient, {
-      releaseId: release3.id,
+      releaseUuid: release3.id,
       userDbId: testUserInsert.id,
       role: "DataOwner",
     });
 
     await addUserToReleaseWithRole.run(edgeDbClient, {
-      releaseId: release4.id,
+      releaseUuid: release4.id,
       userDbId: testUserInsert.id,
       role: "Member",
     });
@@ -129,7 +129,7 @@ describe("edgedb release queries tests", () => {
       expect(result1).not.toBeNull();
       expect(result1).toHaveProperty("releaseParticipant");
       expect(result1!.releaseParticipant.length).toBe(1);
-      expect(result1!.releaseParticipant[0].releaseIdentifier).toBe("R00002");
+      expect(result1!.releaseParticipant[0].releaseIdentifier).toBe("R002");
     }
 
     {
@@ -142,7 +142,7 @@ describe("edgedb release queries tests", () => {
       expect(result2).not.toBeNull();
       expect(result2).toHaveProperty("releaseParticipant");
       expect(result2!.releaseParticipant.length).toBe(1);
-      expect(result2!.releaseParticipant[0].releaseIdentifier).toBe("R00004");
+      expect(result2!.releaseParticipant[0].releaseIdentifier).toBe("R004");
     }
   });
 });

--- a/application/backend/tests/db-tests/edgedb-release-queries.test.ts
+++ b/application/backend/tests/db-tests/edgedb-release-queries.test.ts
@@ -70,7 +70,7 @@ describe("edgedb release queries tests", () => {
     {
       const a = result!.releaseParticipant[0];
 
-      expect(a.releaseIdentifier).toBe("P4RF4AC5BR");
+      expect(a.releaseIdentifier).toBe("R00003");
       expect(a.applicationDacTitle).toBe("An Invisible Study");
       expect(a["@role"]).toBe("DataOwner");
     }
@@ -78,7 +78,7 @@ describe("edgedb release queries tests", () => {
     {
       const b = result!.releaseParticipant[1];
 
-      expect(b.releaseIdentifier).toBe("RH5WOR7QXB");
+      expect(b.releaseIdentifier).toBe("R00002");
       expect(b.applicationDacTitle).toBe("A Better Study of Limited Test Data");
       expect(b["@role"]).toBe("PI");
     }
@@ -129,9 +129,7 @@ describe("edgedb release queries tests", () => {
       expect(result1).not.toBeNull();
       expect(result1).toHaveProperty("releaseParticipant");
       expect(result1!.releaseParticipant.length).toBe(1);
-      expect(result1!.releaseParticipant[0].releaseIdentifier).toBe(
-        "RH5WOR7QXB"
-      );
+      expect(result1!.releaseParticipant[0].releaseIdentifier).toBe("R00002");
     }
 
     {
@@ -144,9 +142,7 @@ describe("edgedb release queries tests", () => {
       expect(result2).not.toBeNull();
       expect(result2).toHaveProperty("releaseParticipant");
       expect(result2!.releaseParticipant.length).toBe(1);
-      expect(result2!.releaseParticipant[0].releaseIdentifier).toBe(
-        "S9DT3Z9NMA"
-      );
+      expect(result2!.releaseParticipant[0].releaseIdentifier).toBe("R00004");
     }
   });
 });

--- a/application/backend/tests/db-tests/edgedb-release-queries.test.ts
+++ b/application/backend/tests/db-tests/edgedb-release-queries.test.ts
@@ -129,14 +129,14 @@ describe("edgedb release queries tests", () => {
       expect(result1).not.toBeNull();
       expect(result1).toHaveProperty("releaseParticipant");
       expect(result1!.releaseParticipant.length).toBe(1);
-      expect(result1!.releaseParticipant[0].releaseIdentifier).toBe("R002");
+      expect(result1!.releaseParticipant[0].releaseIdentifier).toBe("R003");
     }
 
     {
       const result2 = await allReleasesSummaryByUserQuery.run(edgeDbClient, {
         userDbId: testUserInsert.id,
         limit: 1,
-        offset: 2,
+        offset: 0,
       });
 
       expect(result2).not.toBeNull();

--- a/application/backend/tests/integration-tests/http.patch-schema-handling.test.ts
+++ b/application/backend/tests/integration-tests/http.patch-schema-handling.test.ts
@@ -18,6 +18,7 @@ import {
 import { JUDY_SPECIMEN } from "../../src/test-data/insert-test-data-10f-jetsons";
 import { ReleasePatchOperationType } from "@umccr/elsa-types";
 import { TEST_SUBJECT_1 } from "../../src/test-data/insert-test-users";
+import { getNextReleaseId } from "../../src/business/db/release-queries";
 
 describe("http patch schema handling tests", () => {
   let server: FastifyInstance;
@@ -73,7 +74,7 @@ describe("http patch schema handling tests", () => {
         isAllowedReadData: true,
         isAllowedVariantData: true,
         isAllowedPhenotypeData: true,
-        releaseIdentifier: "A",
+        releaseIdentifier: getNextReleaseId(),
         releasePassword: "A", // pragma: allowlist secret
         // we pre-select a bunch of specimens across 10g and 10f
         selectedSpecimens: e.set(

--- a/application/backend/tests/service-tests/utils.ts
+++ b/application/backend/tests/service-tests/utils.ts
@@ -14,7 +14,7 @@ export async function findDatabaseRelease(client: Client, releaseId: string) {
       applicationCoded: {
         ...e.release.ApplicationCoded["*"],
       },
-      filter: e.op(r.id, "=", e.uuid(releaseId)),
+      filter: e.op(r.releaseIdentifier, "=", releaseId),
     }))
     .assert_single()
     .run(client);

--- a/application/backend/tests/test-elsa-settings.common.ts
+++ b/application/backend/tests/test-elsa-settings.common.ts
@@ -97,4 +97,5 @@ export const createTestElsaSettings: () => ElsaSettings = () => ({
     allowTestUsers: true,
   },
   maxmindDbAssetPath: "asset/maxmind/db/",
+  releaseIdPrefix: "R",
 });

--- a/application/frontend/src/index-router.tsx
+++ b/application/frontend/src/index-router.tsx
@@ -155,7 +155,8 @@ export function createRouter(addBypassLoginPage: boolean) {
             </Route>
           </Route>
 
-          <Route path={`datasets`} element={<DatasetsDashboardPage />}>
+          <Route path={`datasets`}>
+            <Route index element={<DatasetsDashboardPage />} />
             <Route path={`:datasetId`} element={<DatasetsDetailPage />} />
           </Route>
 

--- a/application/frontend/src/pages/releases-dashboard/releases-dashboard-page.tsx
+++ b/application/frontend/src/pages/releases-dashboard/releases-dashboard-page.tsx
@@ -77,7 +77,7 @@ export const ReleasesPage: React.FC = () => {
                 <tr
                   key={idx}
                   className="light:bg-gray-800 light:border-gray-700 light:hover:bg-gray-600 border-b bg-white hover:cursor-pointer hover:bg-gray-50"
-                  onClick={() => navigate(`${r.id}/detail`)}
+                  onClick={() => navigate(`${r.releaseIdentifier}/detail`)}
                 >
                   <th
                     scope="row"


### PR DESCRIPTION
Migrate releaseIdentifier from UUID to `RXXX` (where XXX is n<sup>th</sup> of the release record) .

The R stands for Release but is customisable from the config file.


Fix #212 