### PR TITLE
ci: disable missing rate limit code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+query-filters:
+  - exclude:
+      id: js/missing-rate-limiting

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@
 #
 name: "CodeQL"
 
+query-filters:
+  - exclude:
+      id: js/missing-rate-limiting
+
 on:
   push:
     branches: ["dev"]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,10 +11,6 @@
 #
 name: "CodeQL"
 
-query-filters:
-  - exclude:
-      id: js/missing-rate-limiting
-
 on:
   push:
     branches: ["dev"]
@@ -49,6 +45,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Disables the [missing rate limit](https://codeql.github.com/codeql-query-help/javascript/js-missing-rate-limiting/) codeql scanning query.