### PR TITLE
Added cilogon

### DIFF
--- a/application/backend/src/app.ts
+++ b/application/backend/src/app.ts
@@ -80,7 +80,7 @@ export class App {
         contentSecurityPolicy: {
           directives: {
             // TODO: derive form action hosts from configuration of OIDC
-            formAction: ["'self'", "*.cilogon.org"],
+            formAction: ["'self'", "*.cilogon.org", "cilogon.org"],
             // our front end needs to be able to make fetches from ontoserver
             connectSrc: ["'self'", new URL(this.settings.ontoFhirUrl).host],
           },


### PR DESCRIPTION
Realised that in the deployed dev version - we also need the ability to redirect to the straight `cilogon.org` as well as `test.cilogon.org`.

This will all go away once we do some more OIDC work
