### PR TITLE
Make pino transport inherit global log level

### DIFF
--- a/application/backend/src/bootstrap-settings.ts
+++ b/application/backend/src/bootstrap-settings.ts
@@ -65,6 +65,11 @@ export async function bootstrapSettings(config: any): Promise<ElsaSettings> {
       },
     ];
 
+  const logLevel = config.get("logger.level");
+
+  if (logLevel)
+    loggerTransportTargets.forEach(l => l.level ??= logLevel);
+
   return {
     deployedUrl: deployedUrl,
     host: config.get("host"),
@@ -89,7 +94,7 @@ export async function bootstrapSettings(config: any): Promise<ElsaSettings> {
     remsUrl: "https://hgpp-rems.dev.umccr.org",
     logger: {
       name: "elsa-data",
-      level: config.get("logger.level"),
+      level: logLevel,
       transport: {
         targets: loggerTransportTargets,
       },

--- a/application/backend/src/entrypoint.ts
+++ b/application/backend/src/entrypoint.ts
@@ -71,6 +71,7 @@ function printHelpText() {
   logger.trace("Logger trace test");
   logger.debug("Logger debug test");
   logger.info("Logger info test");
+  logger.warn("Logger warn test");
   logger.error("Logger error test");
   logger.fatal("Logger fatal test");
 


### PR DESCRIPTION
Closes https://github.com/umccr/elsa-data/issues/229.

Pino transport targets have their own log levels which are independent of the global `level:` setting. This PR causes the transport targets to inherit the global level unless those targets set their own level.