### PR TITLE
Feature/cloudflare keys begin

### DIFF
--- a/application/backend/src/bootstrap-dependency-injection.ts
+++ b/application/backend/src/bootstrap-dependency-injection.ts
@@ -8,6 +8,7 @@ import { SES } from "@aws-sdk/client-ses";
 import { IPresignedUrlProvider } from "./business/services/presigned-urls-service";
 import { AwsPresignedUrlsService } from "./business/services/aws-presigned-urls-service";
 import { GcpPresignedUrlsService } from "./business/services/gcp-presigned-urls-service";
+import { CloudflarePresignedUrlsService } from "./business/services/cloudflare-presigned-urls-service";
 
 export function bootstrapDependencyInjection() {
   container.register<edgedb.Client>("Database", {
@@ -51,5 +52,8 @@ export function bootstrapDependencyInjection() {
   });
   container.register<IPresignedUrlProvider>("IPresignedUrlProvider", {
     useClass: GcpPresignedUrlsService,
+  });
+  container.register<IPresignedUrlProvider>("IPresignedUrlProvider", {
+    useClass: CloudflarePresignedUrlsService,
   });
 }

--- a/application/backend/src/bootstrap-settings.ts
+++ b/application/backend/src/bootstrap-settings.ts
@@ -67,8 +67,15 @@ export async function bootstrapSettings(config: any): Promise<ElsaSettings> {
 
   const logLevel = config.get("logger.level");
 
-  if (logLevel)
-    loggerTransportTargets.forEach(l => l.level ??= logLevel);
+  if (logLevel) loggerTransportTargets.forEach((l) => (l.level ??= logLevel));
+
+  const hasAws =
+    config.has("aws.signingAccessKeyId") &&
+    config.has("aws.signingSecretAccessKey") &&
+    config.has("aws.tempBucket");
+  const hasCloudflare =
+    config.has("cloudflare.signingAccessKeyId") &&
+    config.has("cloudflare.signingAccessKeyId");
 
   return {
     deployedUrl: deployedUrl,
@@ -84,9 +91,19 @@ export async function bootstrapSettings(config: any): Promise<ElsaSettings> {
     oidcClientId: config.get("oidc.clientId")!,
     oidcClientSecret: config.get("oidc.clientSecret")!,
     oidcIssuer: issuer,
-    awsSigningAccessKeyId: config.get("aws.signingAccessKeyId")!,
-    awsSigningSecretAccessKey: config.get("aws.signingSecretAccessKey")!,
-    awsTempBucket: config.get("aws.tempBucket")!,
+    aws: hasAws
+      ? {
+          signingAccessKeyId: config.get("aws.signingAccessKeyId")!,
+          signingSecretAccessKey: config.get("aws.signingSecretAccessKey")!,
+          tempBucket: config.get("aws.tempBucket")!,
+        }
+      : undefined,
+    cloudflare: hasCloudflare
+      ? {
+          signingAccessKeyId: config.get("cloudflare.signingAccessKeyId"),
+          signingSecretAccessKey: config.get("cloudflare.signingAccessKeyId"),
+        }
+      : undefined,
     sessionSecret: config.get("session.secret")!,
     sessionSalt: config.get("session.salt")!,
     remsBotKey: config.get("rems.botKey")!,

--- a/application/backend/src/business/services/aws-access-point-service.ts
+++ b/application/backend/src/business/services/aws-access-point-service.ts
@@ -22,6 +22,7 @@ import { ElsaSettings } from "../../config/elsa-settings";
 import { Logger } from "pino";
 import { getAllFileRecords } from "./_release-file-list-helper";
 import { ReleaseViewError } from "../exceptions/release-authorisation";
+import assert from "assert";
 
 // TODO we need to decide where we get the region from (running setting?) - or is it a config
 const REGION = "ap-southeast-2";
@@ -194,6 +195,8 @@ export class AwsAccessPointService extends AwsBaseService {
     // the AWS guard is switched on as this needs to write out to S3
     this.enabledGuard();
 
+    assert(this.settings.aws);
+
     const { userRole } =
       await this.releaseService.getBoundaryInfoWithThrowOnFailure(
         user,
@@ -216,7 +219,7 @@ export class AwsAccessPointService extends AwsBaseService {
     // files via an access point
     const accessPointTemplates =
       createAccessPointTemplateFromReleaseFileEntries(
-        this.settings.awsTempBucket,
+        this.settings.aws.tempBucket,
         REGION,
         releaseKey,
         filesArray,

--- a/application/backend/src/business/services/aws-presigned-urls-service.ts
+++ b/application/backend/src/business/services/aws-presigned-urls-service.ts
@@ -8,6 +8,7 @@ import { Hash } from "@aws-sdk/hash-node";
 import { formatUrl } from "@aws-sdk/util-format-url";
 import { ElsaSettings } from "../../config/elsa-settings";
 import { IPresignedUrlProvider } from "./presigned-urls-service";
+import assert from "assert";
 
 @injectable()
 @singleton()
@@ -29,16 +30,18 @@ export class AwsPresignedUrlsService
     const s3Client = new S3Client({});
     const awsRegion = await s3Client.config.region();
 
+    assert(this.settings.aws);
+
     // we use the S3 client credentials as a backup - but we actually will prefer to use the static credentials given to
     // us via settings (this is what allows us to extend the share out to 7 days - otherwise we are bound by the lifespan
     // of the running AWS credentials which will normally be hours not days)
     const awsCredentials =
-      this.settings.awsSigningAccessKeyId &&
-      this.settings.awsSigningSecretAccessKey
+      this.settings.aws.signingAccessKeyId &&
+      this.settings.aws.signingSecretAccessKey
         ? {
             sessionToken: undefined,
-            accessKeyId: this.settings.awsSigningAccessKeyId,
-            secretAccessKey: this.settings.awsSigningSecretAccessKey,
+            accessKeyId: this.settings.aws.signingAccessKeyId,
+            secretAccessKey: this.settings.aws.signingSecretAccessKey,
           }
         : s3Client.config.credentials;
 

--- a/application/backend/src/business/services/cloudflare-presigned-urls-service.ts
+++ b/application/backend/src/business/services/cloudflare-presigned-urls-service.ts
@@ -1,0 +1,51 @@
+import { inject, injectable, singleton } from "tsyringe";
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { S3RequestPresigner } from "@aws-sdk/s3-request-presigner";
+import { parseUrl } from "@aws-sdk/url-parser";
+import { Hash } from "@aws-sdk/hash-node";
+import { formatUrl } from "@aws-sdk/util-format-url";
+import { ElsaSettings } from "../../config/elsa-settings";
+import { IPresignedUrlProvider } from "./presigned-urls-service";
+import assert from "assert";
+
+@injectable()
+@singleton()
+export class CloudflarePresignedUrlsService implements IPresignedUrlProvider {
+  readonly protocol = "r2";
+
+  constructor(@inject("Settings") private settings: ElsaSettings) {}
+
+  public get isEnabled() {
+    return !!this.settings.cloudflare;
+  }
+
+  async presign(
+    releaseKey: string,
+    bucket: string,
+    key: string
+  ): Promise<string> {
+    throw new Error("not implemented");
+
+    assert(this.settings.cloudflare);
+
+    const s3ObjectUrl = parseUrl(`https://${bucket}.s3.amazonaws.com/${key}`);
+    s3ObjectUrl.query = {
+      "x-releaseKey": releaseKey,
+    };
+
+    const presigner = new S3RequestPresigner({
+      credentials: {
+        accessKeyId: this.settings.cloudflare!.signingAccessKeyId,
+        secretAccessKey: this.settings.cloudflare!.signingSecretAccessKey,
+      },
+      region: "global",
+      sha256: Hash.bind(null, "sha256"),
+    });
+    const url = formatUrl(
+      await presigner.presign(new HttpRequest(s3ObjectUrl), {
+        expiresIn: 60 * 60 * 24 * 7, // 7 days
+      })
+    );
+    return url;
+  }
+}

--- a/application/backend/src/config/config-constants.ts
+++ b/application/backend/src/config/config-constants.ts
@@ -95,6 +95,22 @@ export const configDefinition = {
       env: `${env_prefix}AWS_TEMP_BUCKET`,
     },
   },
+  cloudflare: {
+    signingAccessKeyId: {
+      doc: "A CloudFlare R2 access key id for a user with read permission of files that can be shared via signed URLs",
+      format: "*",
+      sensitive: false,
+      default: undefined,
+      env: `${env_prefix}AWS_SIGNING_ACCESS_KEY_ID`,
+    },
+    signingSecretAccessKey: {
+      doc: "A CloudFlare R2 secret access key for a user with read permission of files that can be shared via signed URLs",
+      format: "*",
+      sensitive: true,
+      default: undefined,
+      env: `${env_prefix}AWS_SIGNING_SECRET_ACCESS_KEY`,
+    },
+  },
   // the rate limiting options are basically a pass through to the Fastify rate limit plugin
   // for the moment we have picked only a subset of the full configuration items
   rateLimit: {

--- a/application/backend/src/config/elsa-settings.ts
+++ b/application/backend/src/config/elsa-settings.ts
@@ -35,9 +35,18 @@ export type ElsaSettings = {
 
   logger: LoggerOptions;
 
-  awsSigningAccessKeyId: string;
-  awsSigningSecretAccessKey: string;
-  awsTempBucket: string;
+  // optional signing details to allow sharing of objects in AWS
+  aws?: {
+    signingAccessKeyId: string;
+    signingSecretAccessKey: string;
+    tempBucket: string;
+  };
+
+  // optional signing details to allow sharing of objects in CloudFlare R2
+  cloudflare?: {
+    signingAccessKeyId: string;
+    signingSecretAccessKey: string;
+  };
 
   // Read the README.md for GCP-related configuration
 

--- a/application/backend/tests/test-dependency-injection.common.ts
+++ b/application/backend/tests/test-dependency-injection.common.ts
@@ -9,6 +9,7 @@ import { Logger, pino } from "pino";
 import { IPresignedUrlProvider } from "../src/business/services/presigned-urls-service";
 import { AwsPresignedUrlsService } from "../src/business/services/aws-presigned-urls-service";
 import { GcpPresignedUrlsService } from "../src/business/services/gcp-presigned-urls-service";
+import { CloudflarePresignedUrlsService } from "../src/business/services/cloudflare-presigned-urls-service";
 
 export async function registerTypes() {
   // TO *REALLY* USE CHILD CONTAINERS WE'D NEED TO TEACH FASTIFY TO DO THE SAME SO FOR THE MOMENT
@@ -49,6 +50,10 @@ export async function registerTypes() {
 
   testContainer.register<IPresignedUrlProvider>("IPresignedUrlProvider", {
     useClass: GcpPresignedUrlsService,
+  });
+
+  testContainer.register<IPresignedUrlProvider>("IPresignedUrlProvider", {
+    useClass: CloudflarePresignedUrlsService,
   });
 
   return testContainer;


### PR DESCRIPTION
Adds a spot in the config files for R2 signing keys - though no actual implementation yet.

This needs to be in place first so we can edit the shared AWS secrets - and not break other dev instances when they encoutner config fields they don't understand.
