### PR TITLE
Reinforce Permission Cookies Authenticity 

### DIFF
--- a/application/backend/src/api/api-auth-routes.ts
+++ b/application/backend/src/api/api-auth-routes.ts
@@ -32,7 +32,11 @@ import {
   TEST_SUBJECT_3_DISPLAY,
   TEST_SUBJECT_3_EMAIL,
 } from "../test-data/insert-test-users";
-import { cookieForBackend, cookieForUI } from "./helpers/cookie-helpers";
+import {
+  cookieForBackend,
+  cookieForUI,
+  createUserAllowedCookie,
+} from "./helpers/cookie-helpers";
 import { Client } from "edgedb";
 import { Logger } from "pino";
 
@@ -330,36 +334,19 @@ export const callbackRoutes = async (
     cookieForUI(request, reply, USER_NAME_COOKIE_NAME, authUser.displayName);
     cookieForUI(request, reply, USER_EMAIL_COOKIE_NAME, email); // TODO: save this in backend too.. (if needed?)
 
-    // NOTE: this is a UI cookie - the actual enforcement of this grouping at an API layer is elsewhere
-    // we do it this way so that we can centralise all permissions logic on the backend, and hand down
-    // simple "is allowed" decisions to the UI
-    // MAKE SURE ALL THE DECISIONS HERE MATCH THE API AUTH LOGIC - THAT IS THE POINT OF THIS TECHNIQUE
-    const allowed = new Set<string>();
-
-    if (authUser.isAllowedCreateRelease) {
-      allowed.add(ALLOWED_CREATE_NEW_RELEASE);
-    }
-
-    if (authUser.isAllowedRefreshDatasetIndex) {
-      allowed.add(ALLOWED_DATASET_UPDATE);
-    }
-
-    if (
-      authUser.isAllowedChangeUserPermission ||
-      authUser.isAllowedOverallAdministratorView
-    ) {
-      allowed.add(ALLOWED_OVERALL_ADMIN_VIEW);
-    }
-
-    if (authUser.isAllowedChangeUserPermission) {
-      allowed.add(ALLOWED_CHANGE_USER_PERMISSION);
-    }
+    const userAllowedCookieString = createUserAllowedCookie({
+      isAllowedCreateRelease: authUser.isAllowedCreateRelease,
+      isAllowedRefreshDatasetIndex: authUser.isAllowedRefreshDatasetIndex,
+      isAllowedOverallAdministratorView:
+        authUser.isAllowedOverallAdministratorView,
+      isAllowedChangeUserPermission: authUser.isAllowedChangeUserPermission,
+    });
 
     cookieForUI(
       request,
       reply,
       USER_ALLOWED_COOKIE_NAME,
-      Array.from(allowed.values()).join(",")
+      userAllowedCookieString
     );
 
     // CSRF Token passed as cookie

--- a/application/backend/src/api/api-internal-routes.ts
+++ b/application/backend/src/api/api-internal-routes.ts
@@ -123,12 +123,9 @@ export const apiInternalRoutes = async (
 ) => {
   const usersService = opts.container.resolve(UsersService);
 
-  const authInternalHook = createSessionCookieRouteHook(
-    usersService,
-    opts.allowTestCookieEquals != null
-  );
-
   fastify.addHook("preHandler", fastify.csrfProtection);
+
+  const authInternalHook = createSessionCookieRouteHook(usersService);
 
   // now register the auth hook and then register all the rest of our routes nested within
   fastify.addHook("onRequest", authInternalHook).after(() => {

--- a/application/backend/src/api/errors/authentication-error.ts
+++ b/application/backend/src/api/errors/authentication-error.ts
@@ -2,6 +2,6 @@ import { Base7807Error } from "@umccr/elsa-types";
 
 export class NotAuthorisedCredentials extends Base7807Error {
   constructor(message?: string) {
-    super("Not Authorised With Current Credentials.", 401, `${message ?? ""}`);
+    super("Not Authorised With Current Credentials.", 401, message);
   }
 }

--- a/application/backend/src/api/errors/authentication-error.ts
+++ b/application/backend/src/api/errors/authentication-error.ts
@@ -1,0 +1,7 @@
+import { Base7807Error } from "@umccr/elsa-types";
+
+export class NotAuthorisedCredentials extends Base7807Error {
+  constructor(message?: string) {
+    super("Not Authorised With Current Credentials.", 401, `${message ?? ""}`);
+  }
+}

--- a/application/backend/src/api/helpers/cookie-helpers.ts
+++ b/application/backend/src/api/helpers/cookie-helpers.ts
@@ -1,3 +1,9 @@
+import {
+  ALLOWED_CHANGE_USER_PERMISSION,
+  ALLOWED_CREATE_NEW_RELEASE,
+  ALLOWED_DATASET_UPDATE,
+  ALLOWED_OVERALL_ADMIN_VIEW,
+} from "@umccr/elsa-constants";
 import { FastifyReply, FastifyRequest } from "fastify";
 
 /**
@@ -40,4 +46,47 @@ export function cookieForBackend(
     maxAge: 24 * 60 * 60, // 1 day (in seconds)
   });
   request.session.set(k, v);
+}
+
+/**
+ * It will return a string of allowed permissions for UI cookie.
+ *
+ * NOTE: this is a UI cookie - the actual enforcement of this grouping at an API layer is elsewhere
+ * we do it this way so that we can centralise all permissions logic on the backend, and hand down
+ * simple "is allowed" decisions to the UI
+ * MAKE SURE ALL THE DECISIONS HERE MATCH THE API AUTH LOGIC - THAT IS THE POINT OF THIS TECHNIQUE
+ *
+ * @param  props user permissions
+ * @returns
+ */
+export function createUserAllowedCookie({
+  isAllowedCreateRelease,
+  isAllowedRefreshDatasetIndex,
+  isAllowedOverallAdministratorView,
+  isAllowedChangeUserPermission,
+}: {
+  isAllowedCreateRelease: boolean;
+  isAllowedRefreshDatasetIndex: boolean;
+  isAllowedOverallAdministratorView: boolean;
+  isAllowedChangeUserPermission: boolean;
+} & Record<string, any>): string {
+  const allowed = new Set<string>();
+
+  if (isAllowedCreateRelease) {
+    allowed.add(ALLOWED_CREATE_NEW_RELEASE);
+  }
+
+  if (isAllowedRefreshDatasetIndex) {
+    allowed.add(ALLOWED_DATASET_UPDATE);
+  }
+
+  if (isAllowedOverallAdministratorView) {
+    allowed.add(ALLOWED_OVERALL_ADMIN_VIEW);
+  }
+
+  if (isAllowedChangeUserPermission) {
+    allowed.add(ALLOWED_CHANGE_USER_PERMISSION);
+  }
+
+  return Array.from(allowed.values()).join(",");
 }

--- a/application/backend/src/api/routes/trpc-bootstrap.ts
+++ b/application/backend/src/api/routes/trpc-bootstrap.ts
@@ -1,6 +1,7 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import { Context } from "./trpc-context";
 import { getAuthenticatedUserFromSecureSession } from "../auth/session-cookie-helpers";
+import { createUserAllowedCookie } from "../helpers/cookie-helpers";
 
 const t = initTRPC.context<Context>().create();
 
@@ -10,9 +11,8 @@ export const middleware = t.middleware;
 /**
  * Middleware the requires there be a secure session cookie for the logged in user.
  */
-const isSessionCookieAuthed = t.middleware(({ next, ctx }) => {
+const isSessionCookieAuthed = t.middleware(async ({ next, ctx }) => {
   const authedUser = getAuthenticatedUserFromSecureSession(ctx.req);
-
   if (!authedUser) {
     ctx.req.log.error(
       "isSessionCookieAuthed: no session cookie data was present so failing authentication"
@@ -22,8 +22,31 @@ const isSessionCookieAuthed = t.middleware(({ next, ctx }) => {
       code: "UNAUTHORIZED",
     });
   }
-
   ctx.req.log.trace(authedUser, `isCookieSessionAuthed: user details`);
+
+  // Checking cookie with Db
+  const dbUser = await ctx.userService.getBySubjectId(authedUser.subjectId);
+  if (!dbUser) {
+    ctx.req.log.error(
+      "isDbAuthed: no user data was present in database so failing authentication"
+    );
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+    });
+  }
+
+  // Checking cookie permissions
+  const dbPermission = createUserAllowedCookie(dbUser);
+  const sessionPermission = createUserAllowedCookie(authedUser);
+  if (dbPermission != sessionPermission) {
+    ctx.req.log.error(
+      "isCookieDataUpdated: cookie permissions do not match with Db so failing authentication"
+    );
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "User permissions have changed, please try logging back in!",
+    });
+  }
 
   return next({
     ctx: {

--- a/application/backend/src/api/session-cookie-route-hook.ts
+++ b/application/backend/src/api/session-cookie-route-hook.ts
@@ -27,9 +27,11 @@ export function createSessionCookieRouteHook(usersService: UsersService) {
   return async (request: FastifyRequest, reply: FastifyReply) => {
     const authedUser = getAuthenticatedUserFromSecureSession(request);
     if (!authedUser) throw new NotAuthorisedCredentials();
+    request.log.trace(authedUser, `createSessionCookieRouteHook: user details`);
 
     const dbUser = await usersService.getBySubjectId(authedUser.subjectId);
     if (!dbUser) throw new NotAuthorisedCredentials();
+    request.log.trace(dbUser, `databaseUser: user details`);
 
     // Check for permissions different
     const dbPermission = createUserAllowedCookie(dbUser);

--- a/application/backend/src/business/services/release-base-service.ts
+++ b/application/backend/src/business/services/release-base-service.ts
@@ -67,8 +67,6 @@ export abstract class ReleaseBaseService {
     user: AuthenticatedUser,
     releaseKey: string
   ) {
-    this.edgeDbClient.withGlobals;
-
     const boundaryInfo = await releaseGetBoundaryInfo(this.edgeDbClient, {
       userDbId: user.dbId,
       releaseKey: releaseKey,

--- a/application/backend/src/business/services/release-base-service.ts
+++ b/application/backend/src/business/services/release-base-service.ts
@@ -67,7 +67,7 @@ export abstract class ReleaseBaseService {
     user: AuthenticatedUser,
     releaseKey: string
   ) {
-    const isAllowed = user.isAllowedOverallAdministratorView;
+    this.edgeDbClient.withGlobals;
 
     const boundaryInfo = await releaseGetBoundaryInfo(this.edgeDbClient, {
       userDbId: user.dbId,
@@ -76,8 +76,7 @@ export abstract class ReleaseBaseService {
 
     const role = boundaryInfo?.role;
 
-    if (!boundaryInfo || (!role && !isAllowed))
-      throw new ReleaseViewError(releaseKey);
+    if (!boundaryInfo) throw new ReleaseViewError(releaseKey);
 
     return {
       userRole: role as ReleaseRoleStrings,

--- a/application/frontend/src/index.tsx
+++ b/application/frontend/src/index.tsx
@@ -5,14 +5,12 @@ import {
   DeployedEnvironments,
   EnvRelayProvider,
 } from "./providers/env-relay-provider";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import { CookiesProvider } from "react-cookie";
 import { LoggedInUserProvider } from "./providers/logged-in-user-provider";
 import { ErrorBoundary } from "./components/errors";
 import { createRouter } from "./index-router";
-import { httpBatchLink } from "@trpc/client";
-import { trpc } from "./helpers/trpc";
+import { TRPCProvider } from "./providers/trpc-provider";
 
 const rootElement = document.getElementById("root");
 const root = createRoot(rootElement as HTMLElement);
@@ -37,21 +35,6 @@ if (rootElement != null) {
   const tfu =
     rootElement.dataset.terminologyFhirUrl || "undefined terminology FHIR URL";
 
-  const queryClient = new QueryClient({});
-
-  const trpcClient = trpc.createClient({
-    links: [
-      httpBatchLink({
-        url: "/api/trpc",
-        // headers() {
-        //  return {
-        //    authorization: getAuthCookie(),
-        //  };
-        // },
-      }),
-    ],
-  });
-
   root.render(
     <React.StrictMode>
       {/* nested providers - outermost levels of nesting are those that are _least_ likely change dynamically */}
@@ -64,17 +47,14 @@ if (rootElement != null) {
           deployedEnvironment={de}
           terminologyFhirUrl={tfu}
         >
-          <trpc.Provider client={trpcClient} queryClient={queryClient}>
-            {/* the query provider comes from react-query and provides standardised remote query semantics */}
-            <QueryClientProvider client={queryClient}>
-              {/* we use session cookies for auth and use this provider to make them easily available */}
-              <CookiesProvider>
-                <LoggedInUserProvider>
-                  <RouterProvider router={createRouter(de === "development")} />
-                </LoggedInUserProvider>
-              </CookiesProvider>
-            </QueryClientProvider>
-          </trpc.Provider>
+          {/* we use session cookies for auth and use this provider to make them easily available */}
+          <CookiesProvider>
+            <LoggedInUserProvider>
+              <TRPCProvider>
+                <RouterProvider router={createRouter(de === "development")} />
+              </TRPCProvider>
+            </LoggedInUserProvider>
+          </CookiesProvider>
         </EnvRelayProvider>
       </ErrorBoundary>
     </React.StrictMode>

--- a/application/frontend/src/pages/users-dashboard/other-users/permission-dialog.tsx
+++ b/application/frontend/src/pages/users-dashboard/other-users/permission-dialog.tsx
@@ -228,7 +228,7 @@ export const PermissionDialog: React.FC<{ user: UserProps }> = ({ user }) => {
                   {isSuccess && (
                     // For temporary, user need to re-logged in order to get latest permission in their UI.
                     <div className="w-full bg-green-200 py-2 text-center text-xs">
-                      {`Permissions changed saved successfully.`}
+                      {`Permissions changed successfully.`}
                     </div>
                   )}
 

--- a/application/frontend/src/pages/users-dashboard/other-users/permission-dialog.tsx
+++ b/application/frontend/src/pages/users-dashboard/other-users/permission-dialog.tsx
@@ -228,8 +228,7 @@ export const PermissionDialog: React.FC<{ user: UserProps }> = ({ user }) => {
                   {isSuccess && (
                     // For temporary, user need to re-logged in order to get latest permission in their UI.
                     <div className="w-full bg-green-200 py-2 text-center text-xs">
-                      {`Permissions changed saved successfully. (This user need to
-                      re-login)`}
+                      {`Permissions changed saved successfully.`}
                     </div>
                   )}
 

--- a/application/frontend/src/providers/logged-in-user-provider.tsx
+++ b/application/frontend/src/providers/logged-in-user-provider.tsx
@@ -32,6 +32,11 @@ export const LoggedInUserProvider: React.FC<Props> = (props: Props) => {
       if (errCode === 401) {
         removeCookie(USER_SUBJECT_COOKIE_NAME);
       }
+      const errMessage = err?.response?.data?.detail;
+      if (errMessage) {
+        alert(errMessage);
+      }
+
       return Promise.reject(err);
     }
   );

--- a/application/frontend/src/providers/trpc-provider.tsx
+++ b/application/frontend/src/providers/trpc-provider.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useCookies } from "react-cookie";
+import { httpBatchLink } from "@trpc/client";
+import { trpc } from "../helpers/trpc";
+import { USER_SUBJECT_COOKIE_NAME } from "@umccr/elsa-constants";
+
+export const TRPCProvider: React.FC<Props> = (props: Props) => {
+  const queryClient = new QueryClient({});
+  const [cookies, _setCookie, removeCookie] = useCookies<any>();
+
+  const trpcClient = trpc.createClient({
+    links: [
+      httpBatchLink({
+        url: "/api/trpc",
+        async fetch(url, options) {
+          const res = await fetch(url, { ...options });
+
+          const errCode = res.status;
+          if (errCode === 401) {
+            removeCookie(USER_SUBJECT_COOKIE_NAME);
+
+            const body = await res?.json();
+            const message = body.length > 0 ? body[0]?.error?.message : "";
+            if (message) alert(message);
+          }
+
+          return res;
+        },
+        // headers() {
+        //  return {
+        //    authorization: getAuthCookie(),
+        //  };
+        // },
+      }),
+    ],
+  });
+
+  return (
+    <>
+      <trpc.Provider client={trpcClient} queryClient={queryClient}>
+        {/* the query provider comes from react-query and provides standardised remote query semantics */}
+        <QueryClientProvider client={queryClient}>
+          {props.children}
+        </QueryClientProvider>
+      </trpc.Provider>
+    </>
+  );
+};
+
+type Props = {
+  children: React.ReactNode;
+};


### PR DESCRIPTION
For all internal and `trpc` routes, there will be a permission check with the Db. If these cookie-Db check fail, it will return 401 which led to a redirection to the login page. An alert with a message will display if it happened. This is useful where admin change a user permission where user had logged in with current session.

Manage to attempt modifying UIcookie appropriately for these permissions changed, but `react-cookie` does not detect changes unless using their own `setCookie` function. With this, we also could rely on the information of authUser from `authenticatedRouteOnEntryHelper`.

Also have a chance to play around with [edgedb access policy](https://www.edgedb.com/docs/datamodel/access_policies) which works great in hiding resource from unauthorised user. But, I suppose if we implement this access on the db level, there will be a need for another admin level that could bypass this policy? (e.g. the system will not have a user_uuid to use but need it need to query the Db for a user check OR a powerful user wanted to change somebody else resource) Happy to explore this further, but atm I think this cookie session update should be sufficient for now.

Fix #257 


![Screenshot 2023-03-28 at 18 51 25](https://user-images.githubusercontent.com/61998484/228166675-c9aa49d9-0d6b-4960-af8c-97c3fb382779.png)
