### PR TITLE
bug(backend): fix req and res not being included in the tRPC router context

### DIFF
--- a/application/backend/src/api/api-trpc-routes.ts
+++ b/application/backend/src/api/api-trpc-routes.ts
@@ -1,5 +1,8 @@
 import { FastifyInstance } from "fastify";
-import { fastifyTRPCPlugin } from "@trpc/server/adapters/fastify";
+import {
+  CreateFastifyContextOptions,
+  fastifyTRPCPlugin,
+} from "@trpc/server/adapters/fastify";
 import { appRouter } from "../app-router";
 import { Context } from "./routes/trpc-bootstrap";
 
@@ -14,7 +17,7 @@ export const trpcRoutes = async (
   fastify: FastifyInstance,
   opts: {
     // we need a minimum context that at least provides us with a DI container
-    trpcCreateContext: () => Promise<Context>;
+    trpcCreateContext: (opts: CreateFastifyContextOptions) => Promise<Context>;
   }
 ) => {
   fastify.addHook("preHandler", fastify.csrfProtection);

--- a/application/backend/src/app.ts
+++ b/application/backend/src/app.ts
@@ -20,10 +20,10 @@ import { Logger } from "pino";
 import { apiExternalRoutes } from "./api/api-external-routes";
 import { apiUnauthenticatedRoutes } from "./api/api-unauthenticated-routes";
 import { getMandatoryEnv, IndexHtmlTemplateData } from "./app-env";
-import { appRouter } from "./app-router";
 import { Context } from "./api/routes/trpc-bootstrap";
 import { getSecureSessionOptions } from "./api/auth/session-cookie-helpers";
 import { trpcRoutes } from "./api/api-trpc-routes";
+import { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify";
 
 @injectable()
 @singleton()
@@ -33,7 +33,9 @@ export class App {
   // a absolute path to where static files are to be served from
   public readonly staticFilesPath: string;
 
-  private readonly trpcCreateContext: () => Promise<Context>;
+  private readonly trpcCreateContext: (
+    opts: CreateFastifyContextOptions
+  ) => Promise<Context>;
 
   /**
    * Our constructor does all the setup that can be done without async/await
@@ -63,9 +65,11 @@ export class App {
     });
 
     // similarly for TRPC, start each request context with a copy of the Elsa settings and a custom child DI container
-    this.trpcCreateContext = async () => ({
+    this.trpcCreateContext = async (opts: CreateFastifyContextOptions) => ({
       settings: { ...settings },
       container: dc.createChildContainer(),
+      req: opts.req,
+      res: opts.res,
     });
   }
 


### PR DESCRIPTION
Fixes the missing response and request context in `trpcCreateContext`.

This is just so that we don't all implement that same fix in different PRs. Based on https://github.com/umccr/elsa-data/pull/270#discussion_r1152787524.