### PR TITLE
fix(backend): stringify manifest object and include folder prefix

### DIFF
--- a/application/backend/src/business/services/manifests/htsget/manifest-htsget-service.ts
+++ b/application/backend/src/business/services/manifests/htsget/manifest-htsget-service.ts
@@ -102,7 +102,7 @@ export abstract class ManifestHtsgetService {
       }
     }
 
-    if (timeDifference <= 0) {
+    if (timeDifference <= 0 || timeDifference > this.settings.htsget.maxAge) {
       const manifest = await this.getActiveHtsgetManifest(releaseKey);
 
       if (manifest === null) {
@@ -118,7 +118,7 @@ export abstract class ManifestHtsgetService {
       await this.cloudStorage.put(
         this.settings.aws.tempBucket,
         manifestKey,
-        manifest.toString()
+        JSON.stringify(manifest)
       );
 
       timeDifference = this.settings.htsget.maxAge;
@@ -127,7 +127,7 @@ export abstract class ManifestHtsgetService {
     const output = {
       location: {
         bucket: this.settings.aws.tempBucket,
-        key: releaseKey,
+        key: manifestKey,
       },
       maxAge: timeDifference,
     };

--- a/application/backend/tests/test-elsa-settings.common.ts
+++ b/application/backend/tests/test-elsa-settings.common.ts
@@ -98,9 +98,11 @@ export const createTestElsaSettings: () => ElsaSettings = () => ({
     uri: "",
     oid: "",
   },
-  awsSigningSecretAccessKey: "A", // pragma: allowlist secret
-  awsSigningAccessKeyId: "B", // pragma: allowlist secret
-  awsTempBucket: "a-temp-bucket",
+  aws: {
+    signingSecretAccessKey: "A", // pragma: allowlist secret
+    signingAccessKeyId: "B", // pragma: allowlist secret
+    tempBucket: "a-temp-bucket",
+  },
   rateLimit: {},
   devTesting: {
     sourceFrontEndDirect: false,


### PR DESCRIPTION
Fixes a few bugs in the htsget manifest route:
* Stringify objects before uploading to S3.
* Include folder prefix in response.
* Fix htsget manifest tests