### PR TITLE
Correct TRPC error handling to be on par with existing REST error handling

### DIFF
--- a/application/backend/src/api/api-trpc-routes.ts
+++ b/application/backend/src/api/api-trpc-routes.ts
@@ -26,6 +26,9 @@ export const trpcRoutes = async (
     trpcOptions: {
       router: appRouter,
       createContext: opts.trpcCreateContext,
+      onError: (error: any) => {
+        fastify.log.error(error.error.cause);
+      },
     },
   });
 };

--- a/application/backend/src/api/api-trpc-routes.ts
+++ b/application/backend/src/api/api-trpc-routes.ts
@@ -5,6 +5,7 @@ import {
 } from "@trpc/server/adapters/fastify";
 import { appRouter } from "../app-router";
 import { Context } from "./routes/trpc-bootstrap";
+import { TRPCError } from "@trpc/server";
 
 /**
  * Define the Fastify setup for TRPC - the TRPC middleware, routes etc is
@@ -26,8 +27,8 @@ export const trpcRoutes = async (
     trpcOptions: {
       router: appRouter,
       createContext: opts.trpcCreateContext,
-      onError: (error: any) => {
-        fastify.log.error(error.error.cause);
+      onError: (opts: { error: TRPCError }) => {
+        fastify.log.error(opts.error.cause);
       },
     },
   });

--- a/application/frontend/src/components/errors.tsx
+++ b/application/frontend/src/components/errors.tsx
@@ -6,6 +6,7 @@ import {
 } from "@umccr/elsa-types/error-types";
 import classNames from "classnames";
 import axios from "axios";
+import { TRPCClientError } from "@trpc/client";
 
 export type ErrorDisplayProps = {
   children?: ReactNode;
@@ -133,6 +134,22 @@ export const ErrorFormatterDetail = ({
           </div>
         );
       }
+    } else if (error instanceof TRPCClientError) {
+      const code = error?.shape?.data?.httpStatus;
+      return (
+        <div className="pl-4 pt-4">
+          <div>
+            <span className="font-bold">message: </span>
+            {error.message}
+          </div>
+          {code && (
+            <div>
+              <span className="font-bold">code: </span>
+              {code}
+            </div>
+          )}
+        </div>
+      );
     } else if (error instanceof Error) {
       return <div className="pl-4 pt-4">{error.message}</div>;
     } else if (

--- a/application/frontend/src/pages/releases/detail/information-box.tsx
+++ b/application/frontend/src/pages/releases/detail/information-box.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { trpc } from "../../../helpers/trpc";
 import { useQueryClient } from "@tanstack/react-query";
+import { EagerErrorBoundary } from "../../../components/errors";
 
 type Props = {
   releaseKey: string;
@@ -39,6 +40,8 @@ export const InformationBox: React.FC<Props> = ({
 
   const activateMutation = trpc.releaseActivation.activate.useMutation();
   const deactivateMutation = trpc.releaseActivation.deactivate.useMutation();
+
+  const error = activateMutation.error ?? deactivateMutation.error;
 
   // some handy state booleans
   const mutationInProgress =
@@ -109,6 +112,13 @@ export const InformationBox: React.FC<Props> = ({
             )}
           </div>
         </div>
+        {error && (
+          <EagerErrorBoundary
+            message="Something went wrong while (de)activating the release."
+            error={error}
+            styling="mt-5 shadow sm:rounded-md bg-red-100"
+          />
+        )}
       </div>
     </Box>
   );


### PR DESCRIPTION
I couldn't find a way to propagate the `Base7807Error`s to the frontend and neither could ChatGPT :'(

tRPC still propagates the `Error`'s `message` property to the frontend, which is better than nothing, but the type is changed and things like `title`, `status`, and `detail` are missing. The `onError` callback in this PR still has access to the original server-side exception (burred in the `error.error.cause`) though, so at least it can be logged to the console.

Closes https://github.com/umccr/elsa-data/issues/258