### PR TITLE
Temporarily skip broken service tests and add the rest to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,10 @@ jobs:
         run: npm run test:integration
         working-directory: application/backend
 
+      - name: Run service tests
+        run: npm run test:service
+        working-directory: application/backend
+
       # setup a cache explicitly for Playwright dependencies (browser dependencies at the OS level)
       # https://justin.poehnelt.com/posts/caching-playwright-in-github-actions/
       - uses: actions/cache@v3

--- a/application/backend/tests/service-tests/ag-s3-import.test.ts
+++ b/application/backend/tests/service-tests/ag-s3-import.test.ts
@@ -329,7 +329,7 @@ describe("AWS s3 client", () => {
     expect(pedigreeRelationshipArray.length).toEqual(2);
   });
 
-  it("Test MOCK 1 insert new Cardiac from s3Key", async () => {
+  it.skip("Test MOCK 1 insert new Cardiac from s3Key", async () => {
     const agService = testContainer.resolve(S3IndexApplicationService);
     const datasetService = testContainer.resolve(DatasetService);
     await datasetService.selectOrInsertDataset({
@@ -374,7 +374,7 @@ describe("AWS s3 client", () => {
     ]);
   });
 
-  it("Test MOCK 2 Updating Checksum", async () => {
+  it.skip("Test MOCK 2 Updating Checksum", async () => {
     const agService = testContainer.resolve(S3IndexApplicationService);
     const datasetService = testContainer.resolve(DatasetService);
     await datasetService.selectOrInsertDataset({
@@ -441,7 +441,7 @@ describe("AWS s3 client", () => {
     expect(totalFileList).toEqual(expect.arrayContaining(expected));
   });
 
-  it("Test MOCK 3 Check file mark unavailable", async () => {
+  it.skip("Test MOCK 3 Check file mark unavailable", async () => {
     const agService = testContainer.resolve(S3IndexApplicationService);
     const datasetService = testContainer.resolve(DatasetService);
     await datasetService.selectOrInsertDataset({
@@ -503,7 +503,7 @@ describe("AWS s3 client", () => {
     }
   });
 
-  it("Test MOCK 4 Multi Study Id", async () => {
+  it.skip("Test MOCK 4 Multi Study Id", async () => {
     const agService = testContainer.resolve(S3IndexApplicationService);
     const datasetService = testContainer.resolve(DatasetService);
     await datasetService.selectOrInsertDataset({
@@ -548,7 +548,7 @@ describe("AWS s3 client", () => {
     ]);
   });
 
-  it("Test User Audit Event", async () => {
+  it.skip("Test User Audit Event", async () => {
     const agService = testContainer.resolve(S3IndexApplicationService);
     const datasetService = testContainer.resolve(DatasetService);
     await datasetService.selectOrInsertDataset({

--- a/application/backend/tests/service-tests/aws-discovery-service.test.ts
+++ b/application/backend/tests/service-tests/aws-discovery-service.test.ts
@@ -14,7 +14,7 @@ describe("Test AWS Discovery Service", () => {
     awsEnabledServiceMock.reset();
   });
 
-  it("find the copy out service if present", async () => {
+  it.skip("find the copy out service if present", async () => {
     awsEnabledServiceMock.enable();
     const awsDiscoveryService = testContainer.resolve(AwsDiscoveryService);
 


### PR DESCRIPTION
Relates to https://github.com/umccr/elsa-data/issues/271.

A couple of questions:

1. @andrewpatto - The tests in `application/backend/tests/service-tests` are what you were referring to, right? They mostly seem to be running already. The mocking just needs some tweaking for the tests I've skipped in this PR. I don't think we'll need to move to something as heavy as localstack for now; fixing the mocks should be fine. All the release tests seem fine too.
2. Is everyone okay with me skipping these tests unconditionally, or should I only skip them in CI? I'll raise a couple of follow-up PRs to fix the mocks shortly. I just figured adding the other service tests to the build was a quick win that'll stop further inadvertent breakages.