### PR TITLE
refactor(backend): try non-strict parsing when strict parsing fails

### DIFF
--- a/application/backend/src/config/config-schema.ts
+++ b/application/backend/src/config/config-schema.ts
@@ -262,5 +262,10 @@ export async function getMetaConfig(meta: string): Promise<ElsaConfiguration> {
 
   // perform validation on the final config object and return it transformed
   // (the transform will do type coercion and setting defaults)
-  return configZodDefinition.strict().parse(configObject);
+  try {
+    return configZodDefinition.strict().parse(configObject);
+  } catch (e) {
+    console.warn(`failed strict parsing: ${e}`);
+    return configZodDefinition.parse(configObject);
+  }
 }


### PR DESCRIPTION
Removes strict parsing to avoid errors when unknown keys are found by providers.