### PR TITLE
fix(backend): add transport targets to deploy config

### DIFF
--- a/application/backend/config/dev-deployed.json5
+++ b/application/backend/config/dev-deployed.json5
@@ -3,6 +3,12 @@
   // but we want to get all the logs so level of debug
   logger: {
     level: "debug",
+    transportTargets: [
+      {
+        target: "pino-pretty",
+        options: { destination: 1, minimumLevel: "debug" },
+      },
+    ],
   },
   htsget: {
     url: "https://htsget.elsa.dev.umccr.org",

--- a/application/backend/config/dev-deployed.json5
+++ b/application/backend/config/dev-deployed.json5
@@ -3,12 +3,6 @@
   // but we want to get all the logs so level of debug
   logger: {
     level: "debug",
-    transportTargets: [
-      {
-        target: "pino-pretty",
-        options: { destination: 1, minimumLevel: "debug" },
-      },
-    ],
   },
   htsget: {
     url: "https://htsget.elsa.dev.umccr.org",

--- a/application/backend/src/config/config-constants.ts
+++ b/application/backend/src/config/config-constants.ts
@@ -177,7 +177,8 @@ export const configZodDefinition = z.object({
         .string()
         .describe(
           "The logging level as per Pino (all the standard level strings + silent)"
-        ),
+        )
+        .default("debug"),
       transportTargets: z
         .array(
           z
@@ -186,7 +187,8 @@ export const configZodDefinition = z.object({
             })
             .passthrough()
         )
-        .describe("An array of Pino logger transport targets configurations"),
+        .describe("An array of Pino logger transport targets configurations")
+        .default([]),
     })
     .default({
       level: "debug",


### PR DESCRIPTION
Adds a transport targets field to the deployed logger config to avoid errors with invalid types