### PR TITLE
Minor Release Page

### DIFF
--- a/application/backend/src/api/routes/internal-trpc/release-router.ts
+++ b/application/backend/src/api/routes/internal-trpc/release-router.ts
@@ -22,6 +22,14 @@ export const releaseRouter = router({
         calculateOffset(page, pageSize)
       );
     }),
+  getSpecificRelease: internalProcedure
+    .input(inputSingleReleaseKey)
+    .query(async ({ input, ctx }) => {
+      const { user } = ctx;
+      const { releaseKey } = input;
+
+      return await ctx.releaseService.get(user, releaseKey);
+    }),
   getReleaseConsent: internalProcedure
     .input(inputSingleReleaseKey.merge(z.object({ nodeId: z.string() })))
     .query(async ({ input, ctx }) => {

--- a/application/backend/src/api/routes/internal-trpc/release-router.ts
+++ b/application/backend/src/api/routes/internal-trpc/release-router.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { calculateOffset, internalProcedure, router } from "../trpc-bootstrap";
+import { inputPaginationParameter } from "./input-schemas-common";
 
 const inputSingleReleaseKey = z.object({
   releaseKey: z.string(),
@@ -9,6 +10,18 @@ const inputSingleReleaseKey = z.object({
  * RPC for release
  */
 export const releaseRouter = router({
+  getAllRelease: internalProcedure
+    .input(inputPaginationParameter)
+    .query(async ({ input, ctx }) => {
+      const { user, pageSize } = ctx;
+      const { page = 1 } = input;
+
+      return await ctx.releaseService.getAll(
+        user,
+        pageSize,
+        calculateOffset(page, pageSize)
+      );
+    }),
   getReleaseConsent: internalProcedure
     .input(inputSingleReleaseKey.merge(z.object({ nodeId: z.string() })))
     .query(async ({ input, ctx }) => {

--- a/application/backend/src/api/routes/internal/release-routes.ts
+++ b/application/backend/src/api/routes/internal/release-routes.ts
@@ -44,23 +44,6 @@ export const releaseRoutes = async (
   );
   const manifestService = _opts.container.resolve(ManifestService);
 
-  fastify.get<{ Reply: ReleaseSummaryType[] }>(
-    "/releases",
-    {},
-    async function (request, reply) {
-      const { authenticatedUser, pageSize, offset } =
-        authenticatedRouteOnEntryHelper(request);
-
-      const allForUser = await releaseService.getAll(
-        authenticatedUser,
-        pageSize,
-        offset
-      );
-
-      sendPagedResult(reply, allForUser);
-    }
-  );
-
   fastify.get<{ Params: { rid: string }; Reply: ReleaseDetailType }>(
     "/releases/:rid",
     {},

--- a/application/backend/src/api/routes/internal/release-routes.ts
+++ b/application/backend/src/api/routes/internal/release-routes.ts
@@ -44,21 +44,6 @@ export const releaseRoutes = async (
   );
   const manifestService = _opts.container.resolve(ManifestService);
 
-  fastify.get<{ Params: { rid: string }; Reply: ReleaseDetailType }>(
-    "/releases/:rid",
-    {},
-    async function (request, reply) {
-      const { authenticatedUser } = authenticatedRouteOnEntryHelper(request);
-
-      const releaseKey = request.params.rid;
-
-      const release = await releaseService.get(authenticatedUser, releaseKey);
-
-      if (release) reply.send(release);
-      else reply.status(400).send();
-    }
-  );
-
   fastify.get<{ Params: { rid: string }; Reply: ReleaseCaseType[] }>(
     "/releases/:rid/cases",
     {},

--- a/application/backend/src/business/services/helpers.ts
+++ b/application/backend/src/business/services/helpers.ts
@@ -137,3 +137,20 @@ export async function getReleaseInfo(
     releaseSelectedCasesQuery,
   };
 }
+
+/**
+ * A temporary to pick external identifiers based on the first value stored in the array.
+ * This function will sort (based on the "system" properties) and take the first value from the externalIdentifier array
+ * @param externalIdentifiers
+ * @returns
+ */
+export function getFirstSystemSortedExternalIdentifierValue(
+  externalIdentifiers?: { system: string; value: string }[]
+): string {
+  if (!externalIdentifiers || externalIdentifiers.length == 0) return "";
+
+  externalIdentifiers.sort((a, b) =>
+    a.system.toLowerCase() > b.system.toLowerCase() ? 1 : -1
+  );
+  return externalIdentifiers[0].value;
+}

--- a/application/backend/src/business/services/manifests/manifest-tsv-helper.ts
+++ b/application/backend/src/business/services/manifests/manifest-tsv-helper.ts
@@ -5,6 +5,7 @@ import type {
 import { ManifestMasterType } from "./manifest-master-types";
 import { unpackFileArtifact } from "../_release-file-list-helper";
 import { PresignedUrlService } from "../presigned-url-service";
+import { getFirstSystemSortedExternalIdentifierValue } from "../helpers";
 
 async function manifestBodyElements(
   datasetSpecimen: any,
@@ -32,9 +33,15 @@ async function manifestBodyElements(
   return await Promise.all(
     signedFileArtifacts.map(async (a) => ({
       ...a,
-      caseId: datasetSpecimen.case_.id,
-      patientId: datasetSpecimen.patient.id,
-      specimenId: datasetSpecimen.id,
+      caseId: getFirstSystemSortedExternalIdentifierValue(
+        datasetSpecimen.case_.externalIdentifiers
+      ),
+      patientId: getFirstSystemSortedExternalIdentifierValue(
+        datasetSpecimen.patient.externalIdentifiers
+      ),
+      specimenId: getFirstSystemSortedExternalIdentifierValue(
+        datasetSpecimen.externalIdentifiers
+      ),
     }))
   );
 }

--- a/application/backend/src/business/services/release-base-service.ts
+++ b/application/backend/src/business/services/release-base-service.ts
@@ -144,6 +144,7 @@ export abstract class ReleaseBaseService {
 
     return {
       id: releaseInfo.id,
+      roleInRelease: userRole,
       lastUpdatedDateTime: releaseInfo.lastUpdated,
       lastUpdatedUserSubjectId: releaseInfo.lastUpdatedSubjectId,
       datasetUris: releaseInfo.datasetUris,

--- a/application/backend/src/business/services/release-service.ts
+++ b/application/backend/src/business/services/release-service.ts
@@ -104,7 +104,7 @@ export class ReleaseService extends ReleaseBaseService {
       releaseKey
     );
 
-    return this.getBase(releaseKey, userRole);
+    return await this.getBase(releaseKey, userRole);
   }
 
   /**

--- a/application/common/elsa-types/schemas-releases.ts
+++ b/application/common/elsa-types/schemas-releases.ts
@@ -59,6 +59,9 @@ export const ReleaseActivationSchema = Type.Object({
 
 export const ReleaseDetailSchema = Type.Object({
   id: Type.String(),
+
+  roleInRelease: Type.String(),
+
   lastUpdatedDateTime: TypeDate,
   lastUpdatedUserSubjectId: Type.String(),
 

--- a/application/frontend/src/pages/releases-dashboard/releases-dashboard-page.tsx
+++ b/application/frontend/src/pages/releases-dashboard/releases-dashboard-page.tsx
@@ -46,9 +46,9 @@ export const ReleasesDashboardPage: React.FC = () => {
             <p className="prose">
               This page normally shows any releases that you are involved in.
               Currently the system thinks you are not involved in any releases -
-              if this is wrong, pl ease contact the project manager or
-              CI/Manager of your project and ask them to check that you are
-              listed as a participant of a release.
+              if this is wrong, please contact the project manager or CI/Manager
+              of your project and ask them to check that you are listed as a
+              participant of a release.
             </p>
             <p className="prose">
               Until this is corrected there is very little functionality enabled

--- a/application/frontend/src/pages/releases/detail/information-box.tsx
+++ b/application/frontend/src/pages/releases/detail/information-box.tsx
@@ -24,12 +24,19 @@ export const InformationBox: React.FC<Props> = ({
   releaseData,
   releaseKey,
 }) => {
+  const isAllowMutateActivation = releaseData.roleInRelease == "Administrator";
+
   // a right aligned list of all our datasets and their visualisation colour/box
   const DatasetList = () => (
-    <ul className="text-right">
+    <ul className="text-left">
       {Array.from(releaseData.datasetMap.entries()).map(([uri, vis], index) => (
-        <li key={index} className="flex flex-row justify-end align-middle">
-          <span className="mr-6 font-mono">{uri}</span>
+        <li
+          key={index}
+          className={`flex flex-row align-middle ${
+            isAllowMutateActivation && "justify-end"
+          }`}
+        >
+          <span className="mx-4 font-mono">{uri}</span>
           <span className="h-6 w-6">{vis}</span>
         </li>
       ))}
@@ -88,13 +95,21 @@ export const InformationBox: React.FC<Props> = ({
           </div>
         )}
 
-        <div className="flex flex-col space-y-2">
-          <ActivateDeactivateButtonRow />
-        </div>
+        {isAllowMutateActivation ? (
+          <>
+            <div className="flex flex-col space-y-2">
+              <ActivateDeactivateButtonRow />
+            </div>
 
-        <div className="flex flex-col space-y-2">
-          <DatasetList />
-        </div>
+            <div className="flex flex-col space-y-2">
+              <DatasetList />
+            </div>
+          </>
+        ) : (
+          <div className="col-span-4 flex flex-col space-y-2">
+            <DatasetList />
+          </div>
+        )}
 
         <div className="collapse-arrow rounded-box collapse col-span-2 border border-base-300 bg-base-100">
           <input type="checkbox" />

--- a/application/frontend/src/pages/releases/detail/information-box.tsx
+++ b/application/frontend/src/pages/releases/detail/information-box.tsx
@@ -95,6 +95,7 @@ export const InformationBox: React.FC<Props> = ({
           </div>
         )}
 
+        {/* Hiding release-activation button if they are not authorised */}
         {isAllowMutateActivation ? (
           <>
             <div className="flex flex-col space-y-2">

--- a/application/frontend/src/pages/releases/queries.ts
+++ b/application/frontend/src/pages/releases/queries.ts
@@ -30,9 +30,9 @@ export const REACT_QUERY_RELEASE_KEYS = {
   getReleaseId: (keys: readonly unknown[]) => keys[2],
 };
 
-export async function makeReleaseTypeLocal(
+export function makeReleaseTypeLocal(
   releaseData: ReleaseDetailType
-): Promise<ReleaseTypeLocal> {
+): ReleaseTypeLocal {
   // the release data comes with only terminology *codes* - so we need to lookup
   // the display terms for the UI
   //if (releaseData.applicationCoded.type === "DS") {

--- a/e2e/tests/superAdmin/dac-manual-release.spec.ts
+++ b/e2e/tests/superAdmin/dac-manual-release.spec.ts
@@ -8,6 +8,8 @@ test.beforeEach(async ({ page }) => {
 test("A release can be created manually which has selectable cases", async ({
   page,
 }) => {
+  test.slow();
+
   await page.goto("./");
 
   await page.getByRole("listitem").filter({ hasText: "DAC" }).click();


### PR DESCRIPTION
- Convert `/release/{releaseKey}` route to TRPC
- Had a the externalIdentifier picker for manifest files
- Hide Activate/Deactivate button if user is not an "Admin" role


<img width="500" alt="Screenshot 2023-05-03 at 17 52 21" src="https://user-images.githubusercontent.com/61998484/235859825-02673db6-1d18-4e27-809a-6111b9e190fb.png">
