### PR TITLE
fix: hide in progress audit events from the audit event tables

### DIFF
--- a/application/backend/dbschema/audit.esdl
+++ b/application/backend/dbschema/audit.esdl
@@ -53,9 +53,7 @@ module audit {
         property details -> json;
 
         # Whether its expected that this audit event will be updated.
-        required inProgress: bool {
-            default := false;
-        }
+        required inProgress: bool;
     }
 
     # An audit event which can be caused by a user.

--- a/application/backend/dbschema/audit.esdl
+++ b/application/backend/dbschema/audit.esdl
@@ -51,6 +51,11 @@ module audit {
         # bespoke JSON with details of the event
 
         property details -> json;
+
+        # Whether its expected that this audit event will be updated.
+        required inProgress: bool {
+            default := false;
+        }
     }
 
     # An audit event which can be caused by a user.

--- a/application/backend/dbschema/migrations/00004.edgeql
+++ b/application/backend/dbschema/migrations/00004.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1euvgge53nurlqopytrvzdmiedqcc4yasuz72lidm7trmbto7t2ha
+    ONTO m17ibvtylic3vcs76juwofv2epzn67br6qow5zynfi3cfqu67utyua
+{
+  ALTER TYPE audit::AuditEvent {
+      CREATE REQUIRED PROPERTY inProgress: std::bool {
+          SET default := false;
+      };
+  };
+};

--- a/application/backend/dbschema/migrations/00004.edgeql
+++ b/application/backend/dbschema/migrations/00004.edgeql
@@ -1,9 +1,9 @@
-CREATE MIGRATION m1euvgge53nurlqopytrvzdmiedqcc4yasuz72lidm7trmbto7t2ha
+CREATE MIGRATION m1g7nv7dyddbdoy5l6yj53gh2dkv2wytkkecpxd23cevmnp3qb44sq
     ONTO m17ibvtylic3vcs76juwofv2epzn67br6qow5zynfi3cfqu67utyua
 {
   ALTER TYPE audit::AuditEvent {
       CREATE REQUIRED PROPERTY inProgress: std::bool {
-          SET default := false;
+          SET REQUIRED USING (<std::bool>false);
       };
   };
 };

--- a/application/backend/dbschema/queries/audit-event/insertReleaseAuditEvent.edgeql
+++ b/application/backend/dbschema/queries/audit-event/insertReleaseAuditEvent.edgeql
@@ -7,5 +7,6 @@ insert ReleaseAuditEvent {
   actionDescription := <optional str>$actionDescription ?? "",
   occurredDateTime := <optional datetime>$occurredDateTime ?? datetime_current(),
   outcome := <optional int16>$outcome ?? 0,
-  details := <optional json>$details ?? {}
+  details := <optional json>$details ?? {},
+  inProgress := <optional bool>$inProgress ?? false
 };

--- a/application/backend/dbschema/queries/audit-event/insertSystemAuditEvent.edgeql
+++ b/application/backend/dbschema/queries/audit-event/insertSystemAuditEvent.edgeql
@@ -5,5 +5,6 @@ insert SystemAuditEvent {
   actionDescription := <optional str>$actionDescription ?? "",
   occurredDateTime := <optional datetime>$occurredDateTime ?? datetime_current(),
   outcome := <optional int16>$outcome ?? 0,
-  details := <optional json>$details ?? {}
+  details := <optional json>$details ?? {},
+  inProgress := <optional bool>$inProgress ?? false
 };

--- a/application/backend/dbschema/queries/audit-event/insertUserAuditEvent.edgeql
+++ b/application/backend/dbschema/queries/audit-event/insertUserAuditEvent.edgeql
@@ -7,5 +7,6 @@ insert UserAuditEvent {
   actionDescription := <optional str>$actionDescription ?? "",
   occurredDateTime := <optional datetime>$occurredDateTime ?? datetime_current(),
   outcome := <optional int16>$outcome ?? 0,
-  details := <optional json>$details ?? {}
+  details := <optional json>$details ?? {},
+  inProgress := <optional bool>$inProgress ?? false
 };

--- a/application/backend/src/business/db/audit-log-queries.ts
+++ b/application/backend/src/business/db/audit-log-queries.ts
@@ -154,6 +154,7 @@ export const addUserAuditEventToReleaseQuery = (
         : "Add user to release",
     outcome: 0,
     details: e.json({ role: role }),
+    inProgress: false,
   });
 };
 
@@ -173,6 +174,7 @@ export const addUserAuditEventPermissionChange = (
     actionDescription: `Change user permission`,
     outcome: 0,
     details: e.json(permission),
+    inProgress: false,
   });
 };
 

--- a/application/backend/src/business/db/audit-log-queries.ts
+++ b/application/backend/src/business/db/audit-log-queries.ts
@@ -58,6 +58,7 @@ export const auditEventProperties = {
   occurredDateTime: true,
   occurredDuration: true,
   outcome: true,
+  inProgress: true,
 } as const;
 
 /**

--- a/application/backend/src/business/services/audit-event-service.ts
+++ b/application/backend/src/business/services/audit-event-service.ts
@@ -123,6 +123,7 @@ export class AuditEventService {
       details: e.json({
         errorMessage: "Audit entry not completed",
       }),
+      inProgress: true,
     });
 
     await this.updateRelease(releaseKey, auditEvent, executor, user);
@@ -189,6 +190,7 @@ export class AuditEventService {
               ? e.duration(diffDuration)
               : null,
           updatedDateTime: e.datetime_current(),
+          inProgress: false,
         },
       }))
       .run(executor);
@@ -259,6 +261,7 @@ export class AuditEventService {
       occurredDateTime: start,
       outcome: 8,
       details: { errorMessage: "Audit entry not completed" },
+      inProgress: true,
     });
 
     // TODO: get the insert AND the update to happen at the same time (easy) - but ALSO get it to return
@@ -358,6 +361,7 @@ export class AuditEventService {
               ? e.duration(diffDuration)
               : null,
           updatedDateTime: e.datetime_current(),
+          inProgress: false,
         },
       }))
       .run(executor);
@@ -384,6 +388,7 @@ export class AuditEventService {
         occurredDateTime: start,
         outcome: 8,
         details: { errorMessage: "Audit entry not completed" },
+        inProgress: true,
       })
     ).id;
   }
@@ -446,6 +451,7 @@ export class AuditEventService {
               ? e.duration(diffDuration)
               : null,
           updatedDateTime: e.datetime_current(),
+          inProgress: false,
         },
       }))
       .run(executor);
@@ -480,19 +486,25 @@ export class AuditEventService {
     );
 
     return createPagedResult(
-      pageOfEntries.map((entry) => ({
-        objectId: entry.id,
-        whoId: entry.whoId,
-        whoDisplayName: entry.whoDisplayName,
-        actionCategory: entry.actionCategory,
-        actionDescription: entry.actionDescription,
-        recordedDateTime: entry.recordedDateTime,
-        updatedDateTime: entry.updatedDateTime,
-        occurredDateTime: entry.occurredDateTime,
-        occurredDuration: entry.occurredDuration?.toString(),
-        outcome: entry.outcome,
-        hasDetails: entry.hasDetails,
-      })),
+      pageOfEntries.flatMap((entry) =>
+        !entry.inProgress
+          ? [
+              {
+                objectId: entry.id,
+                whoId: entry.whoId,
+                whoDisplayName: entry.whoDisplayName,
+                actionCategory: entry.actionCategory,
+                actionDescription: entry.actionDescription,
+                recordedDateTime: entry.recordedDateTime,
+                updatedDateTime: entry.updatedDateTime,
+                occurredDateTime: entry.occurredDateTime,
+                occurredDuration: entry.occurredDuration?.toString(),
+                outcome: entry.outcome,
+                hasDetails: entry.hasDetails,
+              },
+            ]
+          : []
+      ),
       totalEntries
     );
   }
@@ -545,19 +557,26 @@ export class AuditEventService {
     );
 
     return createPagedResult(
-      (await entries.run(executor)).map((entry: any) => ({
-        objectId: entry.id,
-        whoId: entry.whoId,
-        whoDisplayName: entry.whoDisplayName,
-        actionCategory: entry.actionCategory,
-        actionDescription: entry.actionDescription,
-        recordedDateTime: entry.recordedDateTime,
-        updatedDateTime: entry.updatedDateTime,
-        occurredDateTime: entry.occurredDateTime,
-        occurredDuration: entry.occurredDuration?.toString(),
-        outcome: entry.outcome,
-        hasDetails: entry.hasDetails,
-      })),
+      (await entries.run(executor)).flatMap((entry) =>
+        !entry.inProgress
+          ? [
+              {
+                objectId: entry.id,
+                whoId: entry.whoId,
+                whoDisplayName: entry.whoDisplayName,
+                actionCategory: entry.actionCategory,
+                actionDescription: entry.actionDescription,
+                recordedDateTime: entry.recordedDateTime,
+                updatedDateTime: entry.updatedDateTime,
+                occurredDateTime: entry.occurredDateTime,
+                occurredDuration: entry.occurredDuration?.toString(),
+                outcome: entry.outcome,
+                inProgress: entry.inProgress,
+                hasDetails: entry.hasDetails,
+              },
+            ]
+          : []
+      ),
       length
     );
   }
@@ -585,19 +604,25 @@ export class AuditEventService {
     );
 
     return createPagedResult(
-      pageOfEntries.map((entry) => ({
-        objectId: entry.id,
-        whoId: null,
-        whoDisplayName: null,
-        actionCategory: entry.actionCategory,
-        actionDescription: entry.actionDescription,
-        recordedDateTime: entry.recordedDateTime,
-        updatedDateTime: entry.updatedDateTime,
-        occurredDateTime: entry.occurredDateTime,
-        occurredDuration: entry.occurredDuration?.toString(),
-        outcome: entry.outcome,
-        hasDetails: entry.hasDetails,
-      })),
+      pageOfEntries.flatMap((entry) =>
+        !entry.inProgress
+          ? [
+              {
+                objectId: entry.id,
+                whoId: null,
+                whoDisplayName: null,
+                actionCategory: entry.actionCategory,
+                actionDescription: entry.actionDescription,
+                recordedDateTime: entry.recordedDateTime,
+                updatedDateTime: entry.updatedDateTime,
+                occurredDateTime: entry.occurredDateTime,
+                occurredDuration: entry.occurredDuration?.toString(),
+                outcome: entry.outcome,
+                hasDetails: entry.hasDetails,
+              },
+            ]
+          : []
+      ),
       totalEntries
     );
   }

--- a/application/backend/src/business/services/dacs/redcap-import-application-service.ts
+++ b/application/backend/src/business/services/dacs/redcap-import-application-service.ts
@@ -328,6 +328,7 @@ ${roleTable.join("\n")}
               whoDisplayName: user.displayName,
               whoId: user.subjectId,
               occurredDateTime: e.datetime_current(),
+              inProgress: false,
             })
           ),
         })

--- a/application/backend/src/business/services/dacs/rems-service.ts
+++ b/application/backend/src/business/services/dacs/rems-service.ts
@@ -230,6 +230,7 @@ ${JSON.stringify(application["application/applicant"], null, 2)}
               whoDisplayName: user.displayName,
               whoId: user.subjectId,
               occurredDateTime: e.datetime_current(),
+              inProgress: false,
             })
           ),
         })

--- a/application/backend/src/business/services/user-service.ts
+++ b/application/backend/src/business/services/user-service.ts
@@ -235,6 +235,7 @@ export class UserService {
         actionDescription: "Login",
         outcome: 0,
         details: auditDetails,
+        inProgress: false,
       });
 
       return await e

--- a/application/backend/src/test-data/release/insert-test-data-release1.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release1.ts
@@ -136,6 +136,7 @@ export async function insertRelease1(
           whoDisplayName: "System",
           whoId: "system",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         }),
         e.insert(e.audit.ReleaseAuditEvent, {
           actionCategory: "E",

--- a/application/backend/src/test-data/release/insert-test-data-release1.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release1.ts
@@ -136,6 +136,18 @@ export async function insertRelease1(
           whoDisplayName: "System",
           whoId: "system",
           occurredDateTime: e.datetime_current(),
+        }),
+        e.insert(e.audit.ReleaseAuditEvent, {
+          actionCategory: "E",
+          actionDescription: "Test in-progress audit event",
+          outcome: 8,
+          whoDisplayName: "System",
+          whoId: "system",
+          occurredDateTime: e.datetime_current(),
+          details: e.json({
+            errorMessage: "Audit entry not completed",
+          }),
+          inProgress: true,
         })
       ),
       dataEgressRecord: await makeSyntheticDataEgressRecord(),

--- a/application/backend/src/test-data/release/insert-test-data-release2.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release2.ts
@@ -60,6 +60,7 @@ export async function insertRelease2(
           whoDisplayName: releaseProps.releaseAdministrator[0].name,
           whoId: releaseProps.releaseAdministrator[0].subject_id,
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
     })

--- a/application/backend/src/test-data/release/insert-test-data-release3.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release3.ts
@@ -73,6 +73,7 @@ export async function insertRelease3(
           whoDisplayName: "Someone",
           whoId: "a",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
     })

--- a/application/backend/src/test-data/release/insert-test-data-release4.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release4.ts
@@ -78,6 +78,7 @@ export async function insertRelease4(
           whoDisplayName: "Someone",
           whoId: "a",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
     })

--- a/application/backend/src/test-data/release/insert-test-data-release5.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release5.ts
@@ -78,6 +78,7 @@ export async function insertRelease5(
           whoDisplayName: "Someone",
           whoId: "a",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
     })

--- a/application/backend/src/test-data/release/insert-test-data-release6.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release6.ts
@@ -54,6 +54,7 @@ export async function insertRelease6(
           whoDisplayName: "Someone",
           whoId: "a",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
     })

--- a/application/backend/src/test-data/user/insert-user1.ts
+++ b/application/backend/src/test-data/user/insert-user1.ts
@@ -33,6 +33,7 @@ export async function insertUser1(
         actionCategory: "E",
         actionDescription: "Login",
         outcome: 0,
+        inProgress: false,
       }),
     })
     .run(edgeDbClient);

--- a/application/backend/src/test-data/user/insert-user2.ts
+++ b/application/backend/src/test-data/user/insert-user2.ts
@@ -34,6 +34,7 @@ export async function insertUser2(
         actionCategory: "E",
         actionDescription: "Login",
         outcome: 0,
+        inProgress: false,
       }),
     })
     .run(edgeDbClient);

--- a/application/backend/src/test-data/user/insert-user3.ts
+++ b/application/backend/src/test-data/user/insert-user3.ts
@@ -33,6 +33,7 @@ export async function insertUser3(
         actionCategory: "E",
         actionDescription: "Login",
         outcome: 0,
+        inProgress: false,
       }),
     })
     .run(edgeDbClient);

--- a/application/backend/src/test-data/user/insert-user4.ts
+++ b/application/backend/src/test-data/user/insert-user4.ts
@@ -33,6 +33,7 @@ export async function insertUser4(
         actionCategory: "E",
         actionDescription: "Login",
         outcome: 0,
+        inProgress: false,
       }),
     })
     .run(edgeDbClient);

--- a/application/backend/src/test-data/user/insert-user5.ts
+++ b/application/backend/src/test-data/user/insert-user5.ts
@@ -34,6 +34,7 @@ export async function insertUser5(
         actionCategory: "E",
         actionDescription: "Login",
         outcome: 0,
+        inProgress: false,
       }),
     })
     .run(edgeDbClient);

--- a/application/backend/src/test-data/util/test-data-helpers.ts
+++ b/application/backend/src/test-data/util/test-data-helpers.ts
@@ -144,6 +144,7 @@ export async function createTestUser(
           ip: "10.1.1.1",
           browser: "Chrome",
         },
+        inProgress: false,
       }),
     })
     .run(edgeDbClient);

--- a/application/backend/tests/integration-tests/integration.common.ts
+++ b/application/backend/tests/integration-tests/integration.common.ts
@@ -107,6 +107,7 @@ export async function createLoggedInServerWithRelease(role: string) {
           whoDisplayName: "Someone",
           whoId: "a",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
     })

--- a/application/backend/tests/service-tests/audit-event-system.test.ts
+++ b/application/backend/tests/service-tests/audit-event-system.test.ts
@@ -127,3 +127,23 @@ it("audit system duration", async () => {
 
   console.log(JSON.stringify(events));
 });
+
+it("get in progress system entries", async () => {
+  const aeId = await auditEventService.startSystemAuditEvent(
+    "E",
+    "Login",
+    new Date(),
+    edgeDbClient
+  );
+
+  const events = await auditEventService.getSystemEntries(
+    1000,
+    0,
+    "occurredDateTime",
+    false,
+    edgeDbClient
+  );
+
+  const auditEvent = events?.data?.find((element) => element.objectId === aeId);
+  expect(auditEvent).toBeUndefined();
+});

--- a/application/backend/tests/service-tests/audit-event-user.test.ts
+++ b/application/backend/tests/service-tests/audit-event-user.test.ts
@@ -164,3 +164,29 @@ it("get entries with no filter", async () => {
   );
   expect(events).toEqual(null);
 });
+
+it("get in progress user entries", async () => {
+  const aeId = await auditEventService.startUserAuditEvent(
+    existingUser.subjectId,
+    existingUser.displayName,
+    existingUser.dbId,
+    "E",
+    "Login",
+    new Date(),
+    edgeDbClient
+  );
+
+  const events = await auditEventService.getUserEntries(
+    ["user"],
+    existingUser,
+    1000,
+    0,
+    false,
+    "occurredDateTime",
+    false,
+    edgeDbClient
+  );
+
+  const auditEvent = events?.data?.find((element) => element.objectId === aeId);
+  expect(auditEvent).toBeUndefined();
+});

--- a/application/backend/tests/service-tests/releases.common.ts
+++ b/application/backend/tests/service-tests/releases.common.ts
@@ -90,6 +90,7 @@ export async function beforeEachCommon(dc: DependencyContainer) {
           whoDisplayName: "Someone",
           whoId: "a",
           occurredDateTime: e.datetime_current(),
+          inProgress: false,
         })
       ),
       lastDataEgressQueryTimestamp: e.datetime_current(),

--- a/application/common/elsa-types/schemas-releases.ts
+++ b/application/common/elsa-types/schemas-releases.ts
@@ -39,7 +39,7 @@ export const ReleaseParticipantRoleConst = [
   "Member",
 ] as const;
 export type ReleaseParticipantRoleType =
-  typeof ReleaseParticipantRoleConst[number];
+  (typeof ReleaseParticipantRoleConst)[number];
 
 export const ReleaseApplicationCodedTypeSchema = StringUnion([
   "HMB",


### PR DESCRIPTION
Closes #364.

### Changes
* Hides in progress audit events by introducing an `inProgress` property to the `AuditEvent` schema type.