### PR TITLE
Fix/empty release activation

### DIFF
--- a/application/backend/src/api/errors/_error.handler.ts
+++ b/application/backend/src/api/errors/_error.handler.ts
@@ -80,14 +80,14 @@ export function ErrorHandler(
 
   // we can't allow a non-error status to come through this code-path - and if we get one - we have to report this
   // as an internal error
-  if (problemResponse.status < 400) {
+  if (problemResponse.status !== undefined && problemResponse.status < 400) {
     problemResponse.type = "about:blank";
     problemResponse.title = "Internal Server Error";
     problemResponse.status = 500;
   }
 
   reply
-    .code(problemResponse.status)
+    .code(problemResponse.status ?? 404)
     .type("application/problem+json")
     .send(problemResponse);
 }

--- a/application/backend/src/business/exceptions/release-activation.ts
+++ b/application/backend/src/business/exceptions/release-activation.ts
@@ -1,4 +1,5 @@
 import { Base7807Error } from "@umccr/elsa-types/error-types";
+import { TRPCError } from "@trpc/server";
 
 export class ReleaseActivationPermissionError extends Base7807Error {
   constructor(releaseKey: string) {
@@ -36,6 +37,16 @@ export class ReleaseDeactivationStateError extends Base7807Error {
       "An attempt was made to deactivate a release that was not activated",
       400,
       `The release with id '${releaseKey}' is deactivate and hence cannot be deactivated again`
+    );
+  }
+}
+
+export class ReleaseActivatedNothingError extends Base7807Error {
+  constructor(detail: string) {
+    super(
+      "Cannot activate release when nothing will be released",
+      undefined,
+      detail
     );
   }
 }

--- a/application/backend/src/business/services/manifests/manifest-master-helper.ts
+++ b/application/backend/src/business/services/manifests/manifest-master-helper.ts
@@ -33,13 +33,13 @@ export async function transformDbManifestToMasterManifest(
     return false;
   };
 
-  // Check to see if cases/specimens exist to being with before activating a release.
+  // Check to see if cases/specimens exist to begin with before activating a release.
   if (manifest.caseTree.length === 0) {
-    throw new ReleaseActivatedNothingError("no cases selected");
+    throw new ReleaseActivatedNothingError("No cases selected");
   }
   if (manifest.specimenList.length === 0) {
     throw new ReleaseActivatedNothingError(
-      "no specimens for the selected cases"
+      "No specimens for the selected cases"
     );
   }
 
@@ -49,7 +49,7 @@ export async function transformDbManifestToMasterManifest(
     !manifest.releaseIsAllowedGSData &&
     !manifest.releaseIsAllowedR2Data
   ) {
-    throw new ReleaseActivatedNothingError("no data sources enabled");
+    throw new ReleaseActivatedNothingError("No data sources enabled");
   }
 
   // we need to prune the manifest of all files that we should not be giving out access to
@@ -147,7 +147,7 @@ export async function transformDbManifestToMasterManifest(
       )
     ) {
       throw new ReleaseActivatedNothingError(
-        "read data is enabled although there are no read data artifacts"
+        "Read data is enabled but there are no read data artifacts"
       );
     }
     if (
@@ -155,7 +155,7 @@ export async function transformDbManifestToMasterManifest(
       allowedArtifacts.every((a) => !a.vcfFile && !a.tbiFile)
     ) {
       throw new ReleaseActivatedNothingError(
-        "variant data is enabled although there are no variant data artifacts for specimen"
+        "Variant data is enabled but there are no variant data artifacts"
       );
     }
 

--- a/application/common/elsa-types/error-types.ts
+++ b/application/common/elsa-types/error-types.ts
@@ -39,7 +39,7 @@ export const BASE_7807_ABOUT_BLANK = "about:blank";
 export interface Base7807Response {
   type: string;
   title: string;
-  status: number;
+  status?: number;
   detail?: string;
   instance?: string;
 
@@ -51,13 +51,13 @@ export interface Base7807Response {
  * Is this object a Base7807Response.
  */
 export const isBase7807Response = (object: any): object is Base7807Response => {
-  return "type" in object && "title" in object && "status" in object;
+  return "type" in object && "title" in object;
 };
 
 export class Base7807Error extends Error {
   constructor(
     title: string,
-    public status: number,
+    public status?: number,
     public detail?: string,
     public instance?: string
   ) {

--- a/application/frontend/src/components/errors.tsx
+++ b/application/frontend/src/components/errors.tsx
@@ -74,7 +74,7 @@ export const Format7807Error = ({
     <div>
       <h3 className="font-bold">{error.title}</h3>
       <div className="text-xs">
-        {error.status}: {error.detail}
+        {error.status ? `${error.status}: ${error.detail}` : `${error.detail}`}
       </div>
     </div>
   );

--- a/application/frontend/src/pages/releases/detail/information-box.tsx
+++ b/application/frontend/src/pages/releases/detail/information-box.tsx
@@ -86,9 +86,9 @@ export const InformationBox: React.FC<Props> = ({
 
   return (
     <Box heading={releaseData.applicationDacTitle}>
-      <div className="grid grid-cols-2 gap-4 overflow-x-auto">
-        {error && <EagerErrorBoundary error={error} />}
+      {error && <EagerErrorBoundary error={error} />}
 
+      <div className="grid grid-cols-2 gap-4 overflow-x-auto">
         {releaseIsActivated && (
           <div className="alert alert-success col-span-2 shadow-lg">
             <div>


### PR DESCRIPTION
Closes #372

I'm happy for this to be merged after the other PRs.

### Changes
* Shows an error if a release is activated but nothing can be released, if:
    * No cases are selected.
    * No data sources are enabled.
    * There are no specimens.
    * Read or variant data is enabled, but there are no artifacts present for that data type.

### UI
![image](https://github.com/umccr/elsa-data/assets/53923960/18bf00fe-9224-47e4-9f75-e11fbd70c90c)
