### PR TITLE
fix: tooltip overflow

### DIFF
--- a/application/frontend/src/components/audit-event/audit-event-table.tsx
+++ b/application/frontend/src/components/audit-event/audit-event-table.tsx
@@ -474,6 +474,7 @@ export const createColumns = (navigate: NavigateFunction) => {
             description={
               table.getIsAllRowsExpanded() ? "Contract All" : "Expand All"
             }
+            applyCSS={"tooltip-right break-all text-xs font-normal capitalize"}
           />
         ) : null;
       },

--- a/application/frontend/src/components/tooltip.tsx
+++ b/application/frontend/src/components/tooltip.tsx
@@ -16,16 +16,8 @@ export const ToolTip = ({
   description,
 }: ToolTipProps): JSX.Element => {
   return (
-    <div
-      className={classNames("group/tooltip relative inline-block", applyCSS)}
-    >
+    <div className={classNames("tooltip", applyCSS)} data-tip={description}>
       {trigger}
-      <span
-        className="text-normal absolute -left-5 -top-2 hidden -translate-y-full items-center whitespace-nowrap rounded-lg
-          bg-gray-600/75 px-2 py-1 text-center text-sm normal-case text-white group-hover/tooltip:flex"
-      >
-        {description}
-      </span>
     </div>
   );
 };


### PR DESCRIPTION
Closes #368.

It's surprisingly difficult to fix this one, because there is no easy way to ignore a parent's `overflow-auto` css!
I've just moved the tooltip to the right to ignore the issue altogether.

### Changes
* Use DaisyUI tool tip and move the expand all table tool tip to the right.
