### PR TITLE
fix(frontend): activation button should be disabled when data is fetching

### DIFF
--- a/application/frontend/src/pages/releases/detail/information-box.tsx
+++ b/application/frontend/src/pages/releases/detail/information-box.tsx
@@ -10,7 +10,7 @@ import { EagerErrorBoundary } from "../../../components/errors";
 type Props = {
   releaseKey: string;
   releaseData: ReleaseTypeLocal;
-  isFetching: boolean;
+  releaseDataIsFetching: boolean;
 };
 
 /**
@@ -19,13 +19,13 @@ type Props = {
  *
  * @param releaseKey the unique key referring to this release
  * @param releaseData the information about this release
- * @param isFetching
+ * @param releaseDataIsFetching
  * @constructor
  */
 export const InformationBox: React.FC<Props> = ({
   releaseData,
   releaseKey,
-  isFetching,
+  releaseDataIsFetching,
 }) => {
   const isAllowMutateActivation = releaseData.roleInRelease == "Administrator";
 
@@ -65,7 +65,9 @@ export const InformationBox: React.FC<Props> = ({
     <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4">
       <button
         className="btn-success btn-lg btn grow"
-        disabled={releaseIsActivated || mutationInProgress || isFetching}
+        disabled={
+          releaseIsActivated || mutationInProgress || releaseDataIsFetching
+        }
         onClick={() =>
           activateMutation.mutate(
             { releaseKey },
@@ -77,7 +79,9 @@ export const InformationBox: React.FC<Props> = ({
       </button>
       <button
         className="btn-warning btn-lg btn grow"
-        disabled={!releaseIsActivated || mutationInProgress || isFetching}
+        disabled={
+          !releaseIsActivated || mutationInProgress || releaseDataIsFetching
+        }
         onClick={() =>
           deactivateMutation.mutate(
             { releaseKey },
@@ -95,7 +99,7 @@ export const InformationBox: React.FC<Props> = ({
       {error && <EagerErrorBoundary error={error} />}
 
       <div className="grid grid-cols-2 gap-4 overflow-x-auto">
-        {releaseIsActivated && !isFetching && (
+        {releaseIsActivated && !releaseDataIsFetching && (
           <div className="alert alert-success col-span-2 shadow-lg">
             <div>
               <span>Data sharing is activated for this release</span>

--- a/application/frontend/src/pages/releases/detail/information-box.tsx
+++ b/application/frontend/src/pages/releases/detail/information-box.tsx
@@ -10,6 +10,7 @@ import { EagerErrorBoundary } from "../../../components/errors";
 type Props = {
   releaseKey: string;
   releaseData: ReleaseTypeLocal;
+  isFetching: boolean;
 };
 
 /**
@@ -18,11 +19,13 @@ type Props = {
  *
  * @param releaseKey the unique key referring to this release
  * @param releaseData the information about this release
+ * @param isFetching
  * @constructor
  */
 export const InformationBox: React.FC<Props> = ({
   releaseData,
   releaseKey,
+  isFetching,
 }) => {
   const isAllowMutateActivation = releaseData.roleInRelease == "Administrator";
 
@@ -52,14 +55,17 @@ export const InformationBox: React.FC<Props> = ({
 
   // some handy state booleans
   const mutationInProgress =
-    activateMutation.isLoading || deactivateMutation.isLoading;
+    activateMutation.isLoading ||
+    activateMutation.isPaused ||
+    deactivateMutation.isLoading ||
+    deactivateMutation.isPaused;
   const releaseIsActivated = !!releaseData.activation;
 
   const ActivateDeactivateButtonRow = () => (
     <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4">
       <button
         className="btn-success btn-lg btn grow"
-        disabled={releaseIsActivated || mutationInProgress}
+        disabled={releaseIsActivated || mutationInProgress || isFetching}
         onClick={() =>
           activateMutation.mutate(
             { releaseKey },
@@ -71,7 +77,7 @@ export const InformationBox: React.FC<Props> = ({
       </button>
       <button
         className="btn-warning btn-lg btn grow"
-        disabled={!releaseIsActivated || mutationInProgress}
+        disabled={!releaseIsActivated || mutationInProgress || isFetching}
         onClick={() =>
           deactivateMutation.mutate(
             { releaseKey },
@@ -89,7 +95,7 @@ export const InformationBox: React.FC<Props> = ({
       {error && <EagerErrorBoundary error={error} />}
 
       <div className="grid grid-cols-2 gap-4 overflow-x-auto">
-        {releaseIsActivated && (
+        {releaseIsActivated && !isFetching && (
           <div className="alert alert-success col-span-2 shadow-lg">
             <div>
               <span>Data sharing is activated for this release</span>

--- a/application/frontend/src/pages/releases/detail/releases-detail-sub-page.tsx
+++ b/application/frontend/src/pages/releases/detail/releases-detail-sub-page.tsx
@@ -14,7 +14,7 @@ import { FEATURE_RELEASE_CONSENT_DISPLAY } from "@umccr/elsa-constants";
  * specific release.
  */
 export const ReleasesDetailSubPage: React.FC = () => {
-  const { releaseKey, releaseData } = useReleasesMasterData();
+  const { releaseKey, releaseData, isFetching } = useReleasesMasterData();
 
   const { features } = useEnvRelay();
 
@@ -24,7 +24,11 @@ export const ReleasesDetailSubPage: React.FC = () => {
 
   return (
     <>
-      <InformationBox releaseKey={releaseKey} releaseData={releaseData} />
+      <InformationBox
+        releaseKey={releaseKey}
+        releaseData={releaseData}
+        isFetching={isFetching}
+      />
 
       <CasesBox
         releaseKey={releaseKey}

--- a/application/frontend/src/pages/releases/detail/releases-detail-sub-page.tsx
+++ b/application/frontend/src/pages/releases/detail/releases-detail-sub-page.tsx
@@ -14,7 +14,8 @@ import { FEATURE_RELEASE_CONSENT_DISPLAY } from "@umccr/elsa-constants";
  * specific release.
  */
 export const ReleasesDetailSubPage: React.FC = () => {
-  const { releaseKey, releaseData, isFetching } = useReleasesMasterData();
+  const { releaseKey, releaseData, releaseDataIsFetching } =
+    useReleasesMasterData();
 
   const { features } = useEnvRelay();
 
@@ -27,7 +28,7 @@ export const ReleasesDetailSubPage: React.FC = () => {
       <InformationBox
         releaseKey={releaseKey}
         releaseData={releaseData}
-        isFetching={isFetching}
+        releaseDataIsFetching={releaseDataIsFetching}
       />
 
       <CasesBox

--- a/application/frontend/src/pages/releases/releases-master-page.tsx
+++ b/application/frontend/src/pages/releases/releases-master-page.tsx
@@ -81,6 +81,7 @@ export const ReleasesMasterPage: React.FC = () => {
     // note: that whilst we might construct the outlet context here with data being undefined (hence needing !),
     // it is ok because in that case we never actually use this masterOutletContext..
     releaseData: releaseQuery.data!,
+    isFetching: releaseQuery.isFetching,
   };
 
   const lastUpdated = releaseQuery.data?.lastUpdatedDateTime as

--- a/application/frontend/src/pages/releases/releases-master-page.tsx
+++ b/application/frontend/src/pages/releases/releases-master-page.tsx
@@ -81,7 +81,7 @@ export const ReleasesMasterPage: React.FC = () => {
     // note: that whilst we might construct the outlet context here with data being undefined (hence needing !),
     // it is ok because in that case we never actually use this masterOutletContext..
     releaseData: releaseQuery.data!,
-    isFetching: releaseQuery.isFetching,
+    releaseDataIsFetching: releaseQuery.isFetching,
   };
 
   const lastUpdated = releaseQuery.data?.lastUpdatedDateTime as

--- a/application/frontend/src/pages/releases/releases-types.ts
+++ b/application/frontend/src/pages/releases/releases-types.ts
@@ -8,7 +8,7 @@ import { useOutletContext } from "react-router-dom";
 export type ReleasesMasterContextType = {
   releaseKey: string;
   releaseData: ReleaseTypeLocal;
-  isFetching: boolean;
+  releaseDataIsFetching: boolean;
 };
 
 export function useReleasesMasterData() {

--- a/application/frontend/src/pages/releases/releases-types.ts
+++ b/application/frontend/src/pages/releases/releases-types.ts
@@ -8,6 +8,7 @@ import { useOutletContext } from "react-router-dom";
 export type ReleasesMasterContextType = {
   releaseKey: string;
   releaseData: ReleaseTypeLocal;
+  isFetching: boolean;
 };
 
 export function useReleasesMasterData() {


### PR DESCRIPTION
Closes #415

Hopefully this disallow pressing the activation buttons when the queries are in progress.

### Changes
* Make the activation and deactivation buttons disabled when data is fetching, or a mutation is running.