### PR TITLE
Fix Unauthorised Message

### DIFF
--- a/application/backend/src/api/api-internal-routes.ts
+++ b/application/backend/src/api/api-internal-routes.ts
@@ -120,6 +120,7 @@ export const apiInternalRoutes = async (
 ) => {
   const userService = opts.container.resolve(UserService);
 
+  // We need to set this as `preHandler` as csrf token might be in the body request
   fastify.addHook("preHandler", fastify.csrfProtection);
 
   const authInternalHook = createSessionCookieRouteHook(userService);

--- a/application/backend/src/api/errors/_error.handler.ts
+++ b/application/backend/src/api/errors/_error.handler.ts
@@ -36,7 +36,7 @@ A problem details object can have the following members:
 
 import { FastifyError, FastifyReply, FastifyRequest } from "fastify";
 import { Base7807Error, Base7807Response } from "@umccr/elsa-types/error-types";
-import { NotAuthorisedCredentials } from "./authentication-error";
+import { NOT_AUTHORISED_MESSAGE } from "./authentication-error";
 
 export function ErrorHandler(
   error: Error,
@@ -71,7 +71,7 @@ export function ErrorHandler(
         (error as any).code == "FST_CSRF_MISSING_SECRET" ||
         (error as any).code == "FST_CSRF_INVALID_TOKEN"
       ) {
-        problemResponse.title = new NotAuthorisedCredentials().message;
+        problemResponse.title = NOT_AUTHORISED_MESSAGE;
         problemResponse.status = 401;
         problemResponse.detail = error.message;
       } else {

--- a/application/backend/src/api/errors/_error.handler.ts
+++ b/application/backend/src/api/errors/_error.handler.ts
@@ -36,6 +36,7 @@ A problem details object can have the following members:
 
 import { FastifyError, FastifyReply, FastifyRequest } from "fastify";
 import { Base7807Error, Base7807Response } from "@umccr/elsa-types/error-types";
+import { NotAuthorisedCredentials } from "./authentication-error";
 
 export function ErrorHandler(
   error: Error,
@@ -70,7 +71,7 @@ export function ErrorHandler(
         (error as any).code == "FST_CSRF_MISSING_SECRET" ||
         (error as any).code == "FST_CSRF_INVALID_TOKEN"
       ) {
-        problemResponse.title = "Expired/Invalid CSRF Token";
+        problemResponse.title = new NotAuthorisedCredentials().message;
         problemResponse.status = 401;
         problemResponse.detail = error.message;
       } else {

--- a/application/backend/src/api/errors/_error.handler.ts
+++ b/application/backend/src/api/errors/_error.handler.ts
@@ -66,6 +66,13 @@ export function ErrorHandler(
         problemResponse.status = 400;
         problemResponse.detail = error.message;
         problemResponse["validation-errors"] = (error as any).validation;
+      } else if (
+        (error as any).code == "FST_CSRF_MISSING_SECRET" ||
+        (error as any).code == "FST_CSRF_INVALID_TOKEN"
+      ) {
+        problemResponse.title = "Expired/Invalid CSRF Token";
+        problemResponse.status = 401;
+        problemResponse.detail = error.message;
       } else {
         if (error.message) {
           problemResponse.detail = error.message;
@@ -77,7 +84,6 @@ export function ErrorHandler(
       "Undefined error object encountered in Fastify error handler - responded with generic 500 error"
     );
   }
-
   // we can't allow a non-error status to come through this code-path - and if we get one - we have to report this
   // as an internal error
   if (problemResponse.status !== undefined && problemResponse.status < 400) {

--- a/application/backend/src/api/errors/authentication-error.ts
+++ b/application/backend/src/api/errors/authentication-error.ts
@@ -2,6 +2,6 @@ import { Base7807Error } from "@umccr/elsa-types";
 
 export class NotAuthorisedCredentials extends Base7807Error {
   constructor(message?: string) {
-    super("Not Authorised With Current Credentials.", 401, message);
+    super("Not authorised with current credentials", 401, message);
   }
 }

--- a/application/backend/src/api/errors/authentication-error.ts
+++ b/application/backend/src/api/errors/authentication-error.ts
@@ -1,7 +1,8 @@
 import { Base7807Error } from "@umccr/elsa-types";
+export const NOT_AUTHORISED_MESSAGE = "Not authorised with current credentials";
 
 export class NotAuthorisedCredentials extends Base7807Error {
   constructor(message?: string) {
-    super("Not authorised with current credentials", 401, message);
+    super(NOT_AUTHORISED_MESSAGE, 401, message);
   }
 }

--- a/application/backend/src/api/routes/trpc-bootstrap.ts
+++ b/application/backend/src/api/routes/trpc-bootstrap.ts
@@ -24,7 +24,7 @@ import { ReleaseSelectionService } from "../../business/services/releases/releas
 import { DacService } from "../../business/services/dacs/dac-service";
 import { AuditEventService } from "../../business/services/audit-event-service";
 import { SharerService } from "../../business/services/sharer-service";
-import { NotAuthorisedCredentials } from "../errors/authentication-error";
+import { NOT_AUTHORISED_MESSAGE } from "../errors/authentication-error";
 
 /**
  * This is the types for the initial context that we guarantee exits for
@@ -74,7 +74,7 @@ const isSessionCookieAuthed = middleware(async ({ next, ctx }) => {
 
     throw new TRPCError({
       code: "UNAUTHORIZED",
-      message: new NotAuthorisedCredentials().message,
+      message: NOT_AUTHORISED_MESSAGE,
     });
   }
   ctx.req.log.trace(authedUser, `isCookieSessionAuthed: user details`);

--- a/application/backend/src/api/routes/trpc-bootstrap.ts
+++ b/application/backend/src/api/routes/trpc-bootstrap.ts
@@ -73,6 +73,7 @@ const isSessionCookieAuthed = middleware(async ({ next, ctx }) => {
 
     throw new TRPCError({
       code: "UNAUTHORIZED",
+      message: "Unauthorised/User session has expired",
     });
   }
   ctx.req.log.trace(authedUser, `isCookieSessionAuthed: user details`);

--- a/application/backend/src/api/routes/trpc-bootstrap.ts
+++ b/application/backend/src/api/routes/trpc-bootstrap.ts
@@ -24,6 +24,7 @@ import { ReleaseSelectionService } from "../../business/services/releases/releas
 import { DacService } from "../../business/services/dacs/dac-service";
 import { AuditEventService } from "../../business/services/audit-event-service";
 import { SharerService } from "../../business/services/sharer-service";
+import { NotAuthorisedCredentials } from "../errors/authentication-error";
 
 /**
  * This is the types for the initial context that we guarantee exits for
@@ -73,7 +74,7 @@ const isSessionCookieAuthed = middleware(async ({ next, ctx }) => {
 
     throw new TRPCError({
       code: "UNAUTHORIZED",
-      message: "Unauthorised/User session has expired",
+      message: new NotAuthorisedCredentials().message,
     });
   }
   ctx.req.log.trace(authedUser, `isCookieSessionAuthed: user details`);

--- a/application/frontend/src/providers/logged-in-user-provider.tsx
+++ b/application/frontend/src/providers/logged-in-user-provider.tsx
@@ -51,7 +51,8 @@ export const LoggedInUserProvider: React.FC<Props> = (props: Props) => {
       if (errCode === 401) {
         removeCookie(USER_SUBJECT_COOKIE_NAME);
 
-        const errMessage = err?.response?.data?.detail;
+        const errMessage =
+          err?.response?.data?.detail ?? err?.response?.data?.title;
         show({
           description: errMessage,
         });

--- a/application/frontend/src/providers/logged-in-user-provider.tsx
+++ b/application/frontend/src/providers/logged-in-user-provider.tsx
@@ -52,7 +52,7 @@ export const LoggedInUserProvider: React.FC<Props> = (props: Props) => {
         removeCookie(USER_SUBJECT_COOKIE_NAME);
 
         const errMessage =
-          err?.response?.data?.detail ?? err?.response?.data?.title;
+          err?.response?.data?.title ?? err?.response?.data?.detail;
         show({
           description: errMessage,
         });

--- a/application/frontend/src/providers/trpc-provider.tsx
+++ b/application/frontend/src/providers/trpc-provider.tsx
@@ -26,7 +26,13 @@ export const TRPCProvider: React.FC<Props> = (props: Props) => {
             removeCookie(USER_SUBJECT_COOKIE_NAME);
 
             const body = await res?.json();
-            const message = body.length > 0 ? body[0]?.error?.message : "";
+
+            // This to grab the layout if the error comes from a 'TRPCError'
+            let message = body.length > 0 ? body[0]?.error?.message : "";
+
+            // Error could also come from a standard Fastify Error
+            if (!message) message = body.title ?? body.detail;
+
             show({
               description: message,
             });


### PR DESCRIPTION
Closes #407 

So for the blank message, it is just the layout of TRPC vs REST error was in a different format. So it was blank for the message.
<img width="300" alt="Screenshot 2023-07-11 at 16 26 44" src="https://github.com/umccr/elsa-data/assets/61998484/7796af73-6b28-456c-b687-4ec6326cf001">

For the browsing here and there after token has expired, after investigating it seems mainly due to csrf token fall into internal server error (500), as it dumps anything else to 500. The default trpc error was 403 error, but I think we could make it 401 and just assume they are no longer authorised. 

A bit more detail: So when the session-cookie expired in the backend, the CSRF-protection  check will also fail. But the order of checking is CSRF token then it goes to our normal auth. Since the last implementation 500 was returned, it was not detected by the FE (as an authentication failure).

