### PR TITLE
fix(backend): add check for setting up emailer sending

### DIFF
--- a/application/backend/config/dev-localhost.json5
+++ b/application/backend/config/dev-localhost.json5
@@ -76,12 +76,12 @@
       name: "Elsa Data",
       address: "no-reply@umccr.org",
     },
+    sendEmails: false,
   },
   devTesting: {
     allowTestUsers: true,
     allowTestRoutes: true,
     mockAwsCloud: true,
-    sendEmails: false,
   },
   superAdmins: [
     {

--- a/application/backend/src/business/services/email-service.ts
+++ b/application/backend/src/business/services/email-service.ts
@@ -131,6 +131,9 @@ export class EmailService {
           ...(this.settings.emailer?.sendEmails !== undefined && {
             send: this.settings.emailer.sendEmails,
           }),
+          ...(this.settings.emailer?.previewEmails !== undefined && {
+            preview: this.settings.emailer.previewEmails,
+          }),
           transport: transport,
         });
 

--- a/application/backend/src/business/services/email-service.ts
+++ b/application/backend/src/business/services/email-service.ts
@@ -21,13 +21,18 @@ export class EmailService {
     @inject(AuditEventService)
     private readonly auditEventService: AuditEventService,
     @inject(AwsEnabledService)
-    private readonly awsEnabledService: AwsEnabledService
+    private readonly awsEnabledService: AwsEnabledService,
   ) {}
 
   /**
    * Setup the mail service.
    */
   public async setup() {
+    if (this.settings.emailer === undefined) {
+      this.logger.info("emailer not set up");
+      return;
+    }
+
     if (
       this.settings.emailer?.mode === "SES" &&
       (await this.awsEnabledService.isEnabled())
@@ -38,12 +43,12 @@ export class EmailService {
           maxConnections: this.settings.emailer.maxConnections,
           sendingRate: this.settings.emailer.sendingRate,
         },
-        this.settings.emailer.defaults
+        this.settings.emailer.defaults,
       );
     } else if (this.settings.emailer?.mode === "SMTP") {
       this.transporter = createTransport(
         this.settings.emailer.options,
-        this.settings.emailer.defaults
+        this.settings.emailer.defaults,
       );
     }
 
@@ -65,7 +70,7 @@ export class EmailService {
   private async retry(
     fn: () => Promise<any>,
     tryCount: number,
-    errMsg: string
+    errMsg: string,
   ): Promise<[any, number]> {
     let err = undefined;
 
@@ -92,7 +97,7 @@ export class EmailService {
     if (this.settings.emailer?.templateDictionary !== undefined) {
       return Object.assign(
         localsReturned,
-        this.settings.emailer.templateDictionary
+        this.settings.emailer.templateDictionary,
       );
     } else {
       return localsReturned;
@@ -108,9 +113,9 @@ export class EmailService {
   public async sendEmailTemplate(
     template: string,
     to: string,
-    locals?: Record<string, string>
+    locals?: Record<string, string>,
   ) {
-    if (this.settings.emailer?.from === undefined) {
+    if (this.settings.emailer === undefined) {
       return;
     }
 
@@ -123,7 +128,9 @@ export class EmailService {
           message: {
             from,
           },
-          send: this.settings.devTesting?.sendEmails,
+          ...(this.settings.emailer?.sendEmails !== undefined && {
+            send: this.settings.emailer.sendEmails,
+          }),
           transport: transport,
         });
 
@@ -138,7 +145,7 @@ export class EmailService {
         });
       },
       this.settings.emailer.from,
-      to
+      to,
     );
   }
 
@@ -149,10 +156,10 @@ export class EmailService {
     sendFn: (
       transporter: Transporter,
       from: Address,
-      to: string
+      to: string,
     ) => Promise<any>,
     from: Address,
-    to: string
+    to: string,
   ): Promise<any> {
     return await this.auditEventService.systemAuditEventPattern(
       "Email sent",
@@ -169,7 +176,7 @@ export class EmailService {
             return await sendFn(this.transporter, from, to);
           },
           tryCount,
-          "sending mail"
+          "sending mail",
         );
 
         await completeAuditFn(
@@ -178,7 +185,7 @@ export class EmailService {
             to,
             tryCount: tried,
           },
-          this.edgeDbClient
+          this.edgeDbClient,
         );
 
         return result;
@@ -188,7 +195,7 @@ export class EmailService {
         to,
       },
       false,
-      4
+      4,
     );
   }
 }

--- a/application/backend/src/config/config-schema-dev.ts
+++ b/application/backend/src/config/config-schema-dev.ts
@@ -7,13 +7,13 @@ export const DevTestingSchema = z.optional(
         .boolean()
         .default(true)
         .describe(
-          "Whether to source the frontend build direct from the dev build location."
+          "Whether to source the frontend build direct from the dev build location.",
         ),
       allowTestUsers: z
         .boolean()
         .default(true)
         .describe(
-          "If test users should be allowed, including various techniques used to adjust user sessions."
+          "If test users should be allowed, including various techniques used to adjust user sessions.",
         ),
       allowTestRoutes: z
         .boolean()
@@ -23,18 +23,12 @@ export const DevTestingSchema = z.optional(
         .boolean()
         .default(false)
         .describe(
-          "If we should replace the AWS cloud clients with ones that always returns mock values."
-        ),
-      sendEmails: z
-        .boolean()
-        .default(false)
-        .describe(
-          "Whether emails should actually be sent or if they are just built and rendered locally."
+          "If we should replace the AWS cloud clients with ones that always returns mock values.",
         ),
     })
     .describe(
-      "Sets the dev config options. Should only have an effect if `NODE_ENV=development` is also set."
-    )
+      "Sets the dev config options. Should only have an effect if `NODE_ENV=development` is also set.",
+    ),
 );
 
 export type DevTestingType = z.infer<typeof DevTestingSchema>;

--- a/application/backend/src/config/config-schema-emailer.ts
+++ b/application/backend/src/config/config-schema-emailer.ts
@@ -20,6 +20,11 @@ const EmailerCommon = {
     .describe(
       "Whether emails should actually be sent or if they are just built and rendered locally. If undefined, sends emails if NODE_ENV is not development.",
     ),
+  previewEmails: z
+    .optional(z.boolean())
+    .describe(
+      "Whether emails should be previewed. If undefined, previews emails if NODE_ENV is development.",
+    ),
   templateDictionary: z
     .record(z.string())
     .default({})

--- a/application/backend/src/config/config-schema-emailer.ts
+++ b/application/backend/src/config/config-schema-emailer.ts
@@ -8,25 +8,30 @@ const EmailerCommon = {
     })
     .required()
     .describe(
-      "Defines the email address and display name that Elsa uses to send emails."
+      "Defines the email address and display name that Elsa uses to send emails.",
     ),
   templateRootPath: z
     .optional(z.string())
     .describe(
-      "The path to the root folder locating the tree of email templates. If left undefined this will resolve to an 'emails' folder in the current directory."
+      "The path to the root folder locating the tree of email templates. If left undefined this will resolve to an 'emails' folder in the current directory.",
+    ),
+  sendEmails: z
+    .optional(z.boolean())
+    .describe(
+      "Whether emails should actually be sent or if they are just built and rendered locally. If undefined, sends emails if NODE_ENV is not development.",
     ),
   templateDictionary: z
     .record(z.string())
     .default({})
     .describe(
       "A dictionary of template values that will be replaced in the pug email templates. This will override" +
-        "the default values passed to locals object in the email template, or add new values if the different templates are used."
+        "the default values passed to locals object in the email template, or add new values if the different templates are used.",
     ),
   defaults: z
     .optional(z.any())
     .describe(
       "Set defaults that get merged into every message object. " +
-        "These are passed directly to the nodemailer createTransport."
+        "These are passed directly to the nodemailer createTransport.",
     ),
 };
 
@@ -47,7 +52,7 @@ const EmailerSMTP = z.object({
     .any()
     .describe(
       "These are passed to the nodemailer createTransport function using the options property: " +
-        "https://nodemailer.com/smtp/#general-options"
+        "https://nodemailer.com/smtp/#general-options",
     ),
   ...EmailerCommon,
 });

--- a/application/backend/tests/test-elsa-settings.common.ts
+++ b/application/backend/tests/test-elsa-settings.common.ts
@@ -43,6 +43,7 @@ export const createTestElsaSettings: () => ElsaSettings = () => ({
       address: "no-reply@example.com",
     },
     templateDictionary: {},
+    sendEmails: true,
   },
   sharers: [
     {
@@ -147,7 +148,6 @@ export const createTestElsaSettings: () => ElsaSettings = () => ({
     allowTestRoutes: true,
     allowTestUsers: true,
     mockAwsCloud: false,
-    sendEmails: true,
   },
   releaseKeyPrefix: "R",
 });


### PR DESCRIPTION
closes #482 

### Changes
* Check to see if the sendEmails flag is set before applying it in the email config, otherwise an undefined value gets converted to false and always previews emails
* Add setting for previewing emails as well, because this is enabled separately to sending them.