### PR TITLE
Feature/dataset sync only by admin

### DIFF
--- a/application/backend/config/dev-localhost.json5
+++ b/application/backend/config/dev-localhost.json5
@@ -3,7 +3,7 @@
   // should then overwrite these empty values
   // in the absence of setting these elsewhere - at least the system will start up - albeit with login problems!
   oidc: {
-    issuerUrl: "https://test.cilogon.org",
+    issuerUrl: "",
     clientId: "aclientid",
     clientSecret: "abc",
   },

--- a/application/backend/src/api/routes/internal-trpc/dataset-router.ts
+++ b/application/backend/src/api/routes/internal-trpc/dataset-router.ts
@@ -40,30 +40,6 @@ export const datasetRouter = router({
       const { datasetUri, includeDeletedFile = false } = input;
       return await ctx.datasetService.get(user, datasetUri, includeDeletedFile);
     }),
-  updateDataset: internalProcedure
-    .input(inputSingleDatasetUri)
-    .mutation(async ({ input, ctx }) => {
-      const { user } = ctx;
-      const { datasetUri } = input;
-
-      // just to work out which service we want to use we ask about the loader for this URI
-      // NOTE we can do all this work without worrying about the calling user because
-      // the list of datasets URIs is already publicly available
-      // and then the loading service will do their own permission checks
-      const loader = ctx.datasetService.getLoaderFromFromDatasetUri(datasetUri);
-
-      switch (loader) {
-        case "australian-genomics-directories":
-          await ctx.agS3IndexService.syncWithDatabaseFromDatasetUri(
-            datasetUri,
-            user,
-            loader
-          );
-          break;
-        default:
-          throw Error(`Unknown dataset or loader for URI ${datasetUri}`);
-      }
-    }),
   getDatasetConsent: internalProcedure
     .input(
       z.object({

--- a/application/backend/src/business/services/australian-genomics/s3-index-import-service.ts
+++ b/application/backend/src/business/services/australian-genomics/s3-index-import-service.ts
@@ -676,18 +676,14 @@ export class S3IndexApplicationService {
    * S3 this will read the directories in S3 and look for new or updated objects.
    *
    * @param datasetUri the URI that defines the dataset in the configuration
-   * @param user the user forcing the synchronisation
    * @param loaderType one of the loader types this service supports
    */
   public async syncWithDatabaseFromDatasetUri(
     datasetUri: string,
-    user: AuthenticatedUser,
-    loaderType:
-      | "australian-genomics-directories"
-      | "australian-genomics-directories-demo"
+    loaderType: "australian-genomics-directories"
   ) {
     // triggering a sync is limited to certain users
-    await this.checkIsImportDatasetAllowed(user, datasetUri);
+    // await this.checkIsImportDatasetAllowed(user, datasetUri);
 
     // TODO this should upset db dataset records to allow us to bootstrap datasets from config
     const datasetId = (
@@ -740,12 +736,8 @@ export class S3IndexApplicationService {
         }
 
         break;
-      case "australian-genomics-directories-demo":
-        throw new Error(
-          "This was written for AG demo but we have a better work around now"
-        );
       default:
-        throw new Error("Unknown loader type");
+        throw new Error(`Unknown loader type '${loaderType}'`);
     }
 
     // Grab all ManifestType object from current edgedb (i.e all the artifacts for a dataset but represented
@@ -1020,11 +1012,11 @@ export class S3IndexApplicationService {
     // Update last update on Dataset
     await this.datasetService.updateDatasetCurrentTimestamp(datasetId, now);
 
-    await this.auditLogService.insertSyncDatasetAuditEvent(
-      user,
-      datasetUri,
-      now,
-      this.edgeDbClient
-    );
+    // await this.auditLogService.insertSyncDatasetAuditEvent(
+    //  user,
+    //  datasetUri,
+    //  now,
+    //  this.edgeDbClient
+    // );
   }
 }

--- a/application/backend/src/entrypoint-command-sync-datasets.ts
+++ b/application/backend/src/entrypoint-command-sync-datasets.ts
@@ -22,7 +22,7 @@ export async function commandSyncDatasets(
   const { settings, logger } = getServices(dc);
   const agIndexService = dc.resolve(S3IndexApplicationService);
 
-  // no point in doing a dataset twice so put into a set
+  // no point in doing a dataset twice - even if the user lists them twice - so put the input into a set
   const datasetUriSet = new Set<string>(datasetUriArray);
 
   for (const datasetUri of datasetUriSet) {
@@ -38,10 +38,10 @@ export async function commandSyncDatasets(
 
         switch (configuredDataset.loader) {
           case "australian-genomics-directories":
-            // TODO not important really as there are other mechanisms to trigger this
-            // need to break this functionality out from the service and have it as a directly
-            // executable code.. OR introduce a user where to perform it
-            // await agIndexService.syncWithDatabaseFromDatasetUri(datasetUri, user, "australian-genomics-directories");
+            await agIndexService.syncWithDatabaseFromDatasetUri(
+              datasetUri,
+              "australian-genomics-directories"
+            );
             break;
           case "dev":
             // I guess we could restrict this loader to literally dev only (we could do a check here) - but this

--- a/application/backend/src/test-data/scenario/insert-scenario1.ts
+++ b/application/backend/src/test-data/scenario/insert-scenario1.ts
@@ -107,13 +107,12 @@ export async function insertScenario1(dc: DependencyContainer) {
 
       await s3IndexService.syncWithDatabaseFromDatasetUri(
         SMARTIE_URI,
-        datasetAdministratorUser,
         "australian-genomics-directories"
       );
     }
   }
 
-  {
+  /*  {
     // this shouldn't be necessary - the synchronise service should upsert this from the config files
     await e
       .insert(e.dataset.Dataset, {
@@ -129,10 +128,11 @@ export async function insertScenario1(dc: DependencyContainer) {
       datasetAdministratorUser,
       "australian-genomics-directories"
     );
-  }
+  } */
 
   const ten_f_uri = await insert10F(dc);
   const ten_c_uri = await insert10C(dc);
+  const ten_g_uri = await insert10G(dc);
   const gs_uri = await insertGs(dc);
 
   // Some blank DB records inserted to see how it looks like

--- a/application/backend/tests/service-tests/australian-genomics/ag-s3-import.test.ts
+++ b/application/backend/tests/service-tests/australian-genomics/ag-s3-import.test.ts
@@ -321,7 +321,6 @@ describe("AWS s3 client", () => {
 
     await agService.syncWithDatabaseFromDatasetUri(
       MOCK_DATASET_URI,
-      user,
       "australian-genomics-directories"
     );
 
@@ -398,7 +397,6 @@ describe("AWS s3 client", () => {
 
     await agService.syncWithDatabaseFromDatasetUri(
       MOCK_DATASET_URI,
-      user,
       "australian-genomics-directories"
     );
 
@@ -470,7 +468,6 @@ describe("AWS s3 client", () => {
 
     await agService.syncWithDatabaseFromDatasetUri(
       MOCK_DATASET_URI,
-      user,
       "australian-genomics-directories"
     );
 
@@ -507,7 +504,6 @@ describe("AWS s3 client", () => {
 
     await agService.syncWithDatabaseFromDatasetUri(
       MOCK_DATASET_URI,
-      user,
       "australian-genomics-directories"
     );
 
@@ -540,6 +536,9 @@ describe("AWS s3 client", () => {
     );
   });
 
+  /* No longer initiated by known user - so no user audit event..
+     possibly migrate to pure system event.. in which case this test is irrelevant anyhow..
+     but here as a reminder
   it("Test User Audit Event", async () => {
     const agService = testContainer.resolve(S3IndexApplicationService);
     const datasetService = testContainer.resolve(DatasetService);
@@ -557,7 +556,6 @@ describe("AWS s3 client", () => {
 
     await agService.syncWithDatabaseFromDatasetUri(
       MOCK_DATASET_URI,
-      user,
       "australian-genomics-directories"
     );
 
@@ -576,4 +574,5 @@ describe("AWS s3 client", () => {
     expect(userAuditEvent[0].whoDisplayName).toEqual(user.displayName);
     expect(userAuditEvent[0].actionCategory).toEqual("U");
   });
+   */
 });

--- a/application/backend/tests/service-tests/aws/s3-index-application.smartie.test.ts
+++ b/application/backend/tests/service-tests/aws/s3-index-application.smartie.test.ts
@@ -59,7 +59,6 @@ describe("Test our Smartie dataset loaded via an S3 mocking layer", () => {
 
     await agService.syncWithDatabaseFromDatasetUri(
       SMARTIE_URI,
-      user,
       "australian-genomics-directories"
     );
 

--- a/application/backend/tests/test-elsa-settings.common.ts
+++ b/application/backend/tests/test-elsa-settings.common.ts
@@ -16,7 +16,7 @@ export const TENG_AWS_EVENT_DATA_STORE_ID = "10g-event-data-store-id";
 // even though our elsa settings are a factory - we don't want to have to do this work every
 // time as it has to go to the internet and discover the CIlogon OIDC settings
 const ciLogonIssuer = new Issuer({
-  issuer: "https://cilogon.org",
+  issuer: "https://test.cilogon.org",
 });
 
 /**

--- a/application/frontend/src/pages/datasets-detail/datasets-detail-page.tsx
+++ b/application/frontend/src/pages/datasets-detail/datasets-detail-page.tsx
@@ -22,21 +22,12 @@ type DatasetsSpecificPageParams = {
 };
 
 export const DatasetsDetailPage: React.FC = () => {
-  const user = useLoggedInUser();
-  const queryClient = useQueryClient();
-
   const { datasetUri: encodedDatasetUri } =
     useParams<DatasetsSpecificPageParams>();
   const datasetUri = decodeURIComponent(encodedDatasetUri ?? "").replaceAll(
     "[dot]",
     "."
   );
-
-  const datasetMutate = trpc.datasetRouter.updateDataset.useMutation({
-    onSettled: () => {
-      queryClient.invalidateQueries();
-    },
-  });
 
   const datasetQuery = trpc.datasetRouter.getSingleDataset.useQuery(
     {
@@ -70,9 +61,6 @@ export const DatasetsDetailPage: React.FC = () => {
         {datasetQuery.isError && (
           <EagerErrorBoundary error={datasetQuery.error} />
         )}
-        {datasetMutate.isError && !datasetQuery.isError && (
-          <EagerErrorBoundary error={datasetMutate.error} />
-        )}
 
         {data && (
           <>
@@ -97,18 +85,6 @@ export const DatasetsDetailPage: React.FC = () => {
               heading={
                 <div className="flex items-center	justify-between">
                   <div>Dataset</div>
-
-                  {user?.isAllowedRefreshDatasetIndex && (
-                    <button
-                      className="btn-outline btn-xs btn ml-2"
-                      onClick={() => datasetMutate.mutate({ datasetUri })}
-                    >
-                      <FontAwesomeIcon
-                        spin={datasetMutate.isLoading}
-                        icon={faRotate}
-                      />
-                    </button>
-                  )}
                 </div>
               }
             >

--- a/e2e/config/e2e.json5
+++ b/e2e/config/e2e.json5
@@ -10,8 +10,8 @@
     },
   },
   oidc: {
-    issuerUrl: "https://test.cilogon.org",
-    clientId: "cilogon:/client_id/53eda5a561fa1d514dbdc94202b5bf9f",
+    issuerUrl: "",
+    clientId: "abcdef",
     clientSecret: "notavalidsecert", // pragma: allowlist secret
   },
   sharers: [

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,29 +7,28 @@
     "": {
       "name": "elsa-data-e2e",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "node-7z": "^3.0.0"
+        "node-7z": "3.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.28.0",
-        "@types/node-7z": "^2.1.5"
+        "@playwright/test": "1.38.1",
+        "@types/node-7z": "2.1.6"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.28.0"
+        "playwright": "1.38.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@types/node": {
@@ -39,9 +38,9 @@
       "dev": true
     },
     "node_modules/@types/node-7z": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/node-7z/-/node-7z-2.1.5.tgz",
-      "integrity": "sha512-ZTcXeMhJPcGzZBjkpc6m3FsWpKlr5OotizwzRNyIjoMo57OQ7RkM5GganOHVE1brMX9tvyr6YEYvfj8LSrx0Nw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node-7z/-/node-7z-2.1.6.tgz",
+      "integrity": "sha512-26aONb5grye/fklu1FXy5NEnbT2QyLA7DoCjQVTT3zAUJRjp/D44oiYrBVj/CLGmAeCJMkVbdxL6vROxaf7JYQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -61,6 +60,20 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/lodash.defaultsdeep": {
@@ -118,28 +131,45 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+    "node_modules/playwright": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
       "dev": true,
+      "dependencies": {
+        "playwright-core": "1.38.1"
+      },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     }
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "playwright-core": "1.28.0"
+        "playwright": "1.38.1"
       }
     },
     "@types/node": {
@@ -149,9 +179,9 @@
       "dev": true
     },
     "@types/node-7z": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/node-7z/-/node-7z-2.1.5.tgz",
-      "integrity": "sha512-ZTcXeMhJPcGzZBjkpc6m3FsWpKlr5OotizwzRNyIjoMo57OQ7RkM5GganOHVE1brMX9tvyr6YEYvfj8LSrx0Nw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node-7z/-/node-7z-2.1.6.tgz",
+      "integrity": "sha512-26aONb5grye/fklu1FXy5NEnbT2QyLA7DoCjQVTT3zAUJRjp/D44oiYrBVj/CLGmAeCJMkVbdxL6vROxaf7JYQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -164,6 +194,13 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
@@ -214,10 +251,20 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "playwright": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.38.1"
+      }
+    },
     "playwright-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
       "dev": true
     }
   }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,20 +2,18 @@
   "name": "elsa-data-e2e",
   "version": "1.0.0",
   "description": "E2E test scripts for any deployment of Elsa Data",
-  "main": "index.js",
   "private": true,
   "scripts": {
     "build": "npm --prefix ../application/frontend run dev:build && npm --prefix ../application/backend run edgetypes",
     "test": "npx playwright test --trace on"
   },
-  "keywords": [],
   "author": "UMCCR",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.28.0",
-    "@types/node-7z": "^2.1.5"
+    "@playwright/test": "1.38.1",
+    "@types/node-7z": "2.1.6"
   },
   "dependencies": {
-    "node-7z": "^3.0.0"
+    "node-7z": "3.0.0"
   }
 }

--- a/e2e/tests/superAdmin/dac-manual-release.spec.ts
+++ b/e2e/tests/superAdmin/dac-manual-release.spec.ts
@@ -40,7 +40,9 @@ test("A release can be created manually which has selectable cases", async ({
 
   // We should now be on the new release's details page. We check that the data
   // we just entered is present in the new release.
-  await expect(page.getByText("My release title")).toBeVisible();
+  await expect(page.getByText("My release title")).toBeVisible({
+    timeout: 30000,
+  });
 
   await expect(
     page.getByText("urn:fdc:umccr.org:2022:dataset/10c")


### PR DESCRIPTION
Moving dataset sync functions to only be available via CMD entrypoint.
This will allow us to split the AWS permissions between the Web and Cmd - so that the Web does not have *any* access to any genomic files. Which lessens any breach surface.

Also, had a strange regression in just the test suite - to do with cilogon now rejected oidc discovery. So have had to introduce some workarounds for that.



