### PR TITLE
S3 Access Point Trackable Egress

### DIFF
--- a/application/backend/dbschema/migrations/00001.edgeql
+++ b/application/backend/dbschema/migrations/00001.edgeql
@@ -1,4 +1,4 @@
-CREATE MIGRATION m137ugc3vykw7m47wqx4xood3o7vzt3shibtmp2xbuxqoecuv5oahq
+CREATE MIGRATION m1ccs3h3r6py43rkmrwmzcwjizpytawdlci2vvlyp7wm4meczdowqa
     ONTO initial
 {
   CREATE MODULE audit IF NOT EXISTS;
@@ -152,15 +152,15 @@ CREATE MIGRATION m137ugc3vykw7m47wqx4xood3o7vzt3shibtmp2xbuxqoecuv5oahq
       CREATE REQUIRED PROPERTY initialTodoCount: std::int32;
   };
   CREATE TYPE release::Activation {
+      CREATE PROPERTY accessPointArns: array<std::str> {
+          SET default := (<array<std::str>>[]);
+      };
       CREATE REQUIRED PROPERTY activatedAt: std::datetime {
           SET default := (std::datetime_current());
           SET readonly := true;
       };
       CREATE REQUIRED PROPERTY activatedByDisplayName: std::str;
       CREATE REQUIRED PROPERTY activatedById: std::str;
-      CREATE PROPERTY awsS3AccessPointAlias: array<std::str> {
-          SET default := (<array<std::str>>[]);
-      };
       CREATE REQUIRED PROPERTY manifest: std::json;
       CREATE REQUIRED PROPERTY manifestEtag: std::str;
   };

--- a/application/backend/dbschema/migrations/00001.edgeql
+++ b/application/backend/dbschema/migrations/00001.edgeql
@@ -1,4 +1,4 @@
-CREATE MIGRATION m1lalck6ohk7f362n3ct6vw5ribeslty7cfyy2z76my5uezv47twha
+CREATE MIGRATION m137ugc3vykw7m47wqx4xood3o7vzt3shibtmp2xbuxqoecuv5oahq
     ONTO initial
 {
   CREATE MODULE audit IF NOT EXISTS;
@@ -57,22 +57,19 @@ CREATE MIGRATION m1lalck6ohk7f362n3ct6vw5ribeslty7cfyy2z76my5uezv47twha
           CREATE CONSTRAINT std::exclusive;
       };
   };
-  CREATE SCALAR TYPE dataset::SexAtBirthType EXTENDING enum<male, female, other>;
-  CREATE TYPE dataset::DatasetPatient EXTENDING dataset::DatasetShareable, dataset::DatasetIdentifiable {
-      CREATE OPTIONAL PROPERTY sexAtBirth: dataset::SexAtBirthType;
-  };
-  ALTER TYPE dataset::DatasetCase {
-      CREATE MULTI LINK patients: dataset::DatasetPatient {
-          ON SOURCE DELETE DELETE TARGET;
-          ON TARGET DELETE ALLOW;
-          CREATE CONSTRAINT std::exclusive;
-      };
-      CREATE LINK dataset := (.<cases[IS dataset::Dataset]);
-  };
   CREATE ABSTRACT TYPE lab::ArtifactBase;
   CREATE TYPE dataset::DatasetSpecimen EXTENDING dataset::DatasetShareable, dataset::DatasetIdentifiable {
       CREATE MULTI LINK artifacts: lab::ArtifactBase;
       CREATE OPTIONAL PROPERTY sampleType: std::str;
+  };
+  CREATE SCALAR TYPE dataset::SexAtBirthType EXTENDING enum<male, female, other>;
+  CREATE TYPE dataset::DatasetPatient EXTENDING dataset::DatasetShareable, dataset::DatasetIdentifiable {
+      CREATE MULTI LINK specimens: dataset::DatasetSpecimen {
+          ON SOURCE DELETE DELETE TARGET;
+          ON TARGET DELETE ALLOW;
+          CREATE CONSTRAINT std::exclusive;
+      };
+      CREATE OPTIONAL PROPERTY sexAtBirth: dataset::SexAtBirthType;
   };
   CREATE SCALAR TYPE storage::ChecksumType EXTENDING enum<MD5, AWS_ETAG, SHA_1, SHA_256>;
   CREATE TYPE storage::File {
@@ -161,6 +158,9 @@ CREATE MIGRATION m1lalck6ohk7f362n3ct6vw5ribeslty7cfyy2z76my5uezv47twha
       };
       CREATE REQUIRED PROPERTY activatedByDisplayName: std::str;
       CREATE REQUIRED PROPERTY activatedById: std::str;
+      CREATE PROPERTY awsS3AccessPointAlias: array<std::str> {
+          SET default := (<array<std::str>>[]);
+      };
       CREATE REQUIRED PROPERTY manifest: std::json;
       CREATE REQUIRED PROPERTY manifestEtag: std::str;
   };
@@ -304,13 +304,16 @@ CREATE MIGRATION m1lalck6ohk7f362n3ct6vw5ribeslty7cfyy2z76my5uezv47twha
   CREATE TYPE consent::ConsentStatementDuo EXTENDING consent::ConsentStatement {
       CREATE REQUIRED PROPERTY dataUseLimitation: std::json;
   };
-  ALTER TYPE dataset::DatasetPatient {
-      CREATE LINK dataset := (.<patients[IS dataset::DatasetCase].<cases[IS dataset::Dataset]);
-      CREATE MULTI LINK specimens: dataset::DatasetSpecimen {
+  ALTER TYPE dataset::DatasetCase {
+      CREATE LINK dataset := (.<cases[IS dataset::Dataset]);
+      CREATE MULTI LINK patients: dataset::DatasetPatient {
           ON SOURCE DELETE DELETE TARGET;
           ON TARGET DELETE ALLOW;
           CREATE CONSTRAINT std::exclusive;
       };
+  };
+  ALTER TYPE dataset::DatasetPatient {
+      CREATE LINK dataset := (.<patients[IS dataset::DatasetCase].<cases[IS dataset::Dataset]);
   };
   ALTER TYPE dataset::DatasetSpecimen {
       CREATE LINK dataset := (.<specimens[IS dataset::DatasetPatient].<patients[IS dataset::DatasetCase].<cases[IS dataset::Dataset]);

--- a/application/backend/dbschema/queries/release-activation/releaseGetAllActivationByReleaseKey.edgeql
+++ b/application/backend/dbschema/queries/release-activation/releaseGetAllActivationByReleaseKey.edgeql
@@ -1,4 +1,5 @@
 # This query will eventually query all release::Activation by releaseKey
+# Expand if need be to return a more thorough result 
 
 with
 
@@ -15,5 +16,16 @@ with
       .releaseKey = <str>$releaseKey
   ),
 
-  allActivation := currReleaseActivation union prevReleaseActivation
+  allActivation := currReleaseActivation union prevReleaseActivation,
 
+  accessPointArns := (select distinct(
+    for a in allActivation
+    union (
+     array_unpack(a.accessPointArns)
+    )
+  )),
+
+  
+select {
+  accessPointArns:=accessPointArns
+};

--- a/application/backend/dbschema/queries/release-activation/releaseGetAllByReleaseKey.edgeql
+++ b/application/backend/dbschema/queries/release-activation/releaseGetAllByReleaseKey.edgeql
@@ -1,0 +1,19 @@
+# This query will eventually query all release::Activation by releaseKey
+
+with
+
+  currReleaseActivation := (
+    select release::Activation
+    filter 
+      .<activation[is release::Release]
+      .releaseKey = <str>$releaseKey
+  ),
+  prevReleaseActivation := (
+    select release::Activation
+    filter 
+      .<previouslyActivated[is release::Release]
+      .releaseKey = <str>$releaseKey
+  ),
+
+  allActivation := currReleaseActivation union prevReleaseActivation
+

--- a/application/backend/dbschema/queries/release-data-egress/updateReleaseDataEgress.edgeql
+++ b/application/backend/dbschema/queries/release-data-egress/updateReleaseDataEgress.edgeql
@@ -8,7 +8,7 @@ set {
 
       egressId := <str>$egressId,
 
-      auditId := <str>$auditId,
+      auditId := <optional str>$auditId,
       occurredDateTime := <datetime>$occurredDateTime,
       description := <str>$description,
 

--- a/application/backend/dbschema/queries/release/releaseGetByReleaseKey.edgeql
+++ b/application/backend/dbschema/queries/release/releaseGetByReleaseKey.edgeql
@@ -3,7 +3,8 @@
 
 select assert_single((
   select release::Release{
-    datasetUris
+    *,
+    dataSharingConfiguration: { * }
   }
   filter
     .releaseKey = <str>$releaseKey

--- a/application/backend/dbschema/release.esdl
+++ b/application/backend/dbschema/release.esdl
@@ -214,7 +214,7 @@ module release {
 
 
         # We wanted to keep track all access point ever installed for this activation release
-        property awsS3AccessPointAlias -> array<str> {
+        property accessPointArns -> array<str> {
             default := <array<str>>[];
         };
 

--- a/application/backend/dbschema/release.esdl
+++ b/application/backend/dbschema/release.esdl
@@ -212,6 +212,12 @@ module release {
         #
         required property manifestEtag -> str;
 
+
+        # We wanted to keep track all access point ever installed for this activation release
+        property awsS3AccessPointAlias -> array<str> {
+            default := <array<str>>[];
+        };
+
     }
 
 

--- a/application/backend/src/business/exceptions/release-activation.ts
+++ b/application/backend/src/business/exceptions/release-activation.ts
@@ -6,7 +6,7 @@ export class ReleaseActivationPermissionError extends Base7807Error {
     super(
       "The user does not have permission to alter the activation state of this release",
       400,
-      `The release with id '${releaseKey}' cannot have its activation state changed by this user`
+      `The release with id '${releaseKey}' cannot have its activation state changed by this user`,
     );
   }
 }
@@ -16,7 +16,7 @@ export class ReleaseNoEditingWhilstActivatedError extends Base7807Error {
     super(
       "An attempt was made to edit fields in a release whilst it is activated",
       400,
-      `The release with id '${releaseKey}' is activated and hence cannot be edited`
+      `The release with id '${releaseKey}' is activated and hence cannot be edited`,
     );
   }
 }
@@ -26,7 +26,7 @@ export class ReleaseActivationStateError extends Base7807Error {
     super(
       "An attempt was made to activate a release that was already activated",
       400,
-      `The release with id '${releaseKey}' is activated and hence cannot be activated again`
+      `The release with id '${releaseKey}' is activated and hence cannot be activated again`,
     );
   }
 }
@@ -36,7 +36,17 @@ export class ReleaseDeactivationStateError extends Base7807Error {
     super(
       "An attempt was made to deactivate a release that was not activated",
       400,
-      `The release with id '${releaseKey}' is deactivate and hence cannot be deactivated again`
+      `The release with id '${releaseKey}' is deactivate and hence cannot be deactivated again`,
+    );
+  }
+}
+
+export class ReleaseDeactivationRunningJobError extends Base7807Error {
+  constructor(releaseKey: string) {
+    super(
+      "An attempt was made to deactivate a release while there is an existing running job",
+      400,
+      `The release with id '${releaseKey}' has an existing running job`,
     );
   }
 }
@@ -46,7 +56,7 @@ export class ReleaseActivatedNothingError extends Base7807Error {
     super(
       "Cannot activate this release because as currently configured no data would actually be contained in the release",
       undefined,
-      detail
+      detail,
     );
   }
 }
@@ -56,7 +66,7 @@ export class ReleaseActivatedMismatchedExpectationsError extends Base7807Error {
     super(
       "Cannot activate this release because as currently configured a data type (e.g. reads) is being requested that would not actually be contained in the release",
       undefined,
-      detail
+      detail,
     );
   }
 }

--- a/application/backend/src/business/services/aws/aws-cloudtrail-lake-service.ts
+++ b/application/backend/src/business/services/aws/aws-cloudtrail-lake-service.ts
@@ -271,7 +271,10 @@ export class AwsCloudTrailLakeService {
             eventDataStoreId: edsi,
           });
 
-          this.logger.debug("SQL statement: ", sqlQueryStatement);
+          this.logger.debug(
+            "CloudTrail PresignedUrl query: ",
+            sqlQueryStatement,
+          );
 
           const newCloudTrailRecords = await this.queryCloudTrailLake({
             sqlQueryStatement: sqlQueryStatement,
@@ -305,7 +308,10 @@ export class AwsCloudTrailLakeService {
               apAlias: a,
             });
 
-            this.logger.debug("SQL statement: ", sqlQueryStatement);
+            this.logger.debug(
+              "CloudTrail AccessPoint SQL Query: ",
+              sqlQueryStatement,
+            );
 
             const newCloudTrailRecords = await this.queryCloudTrailLake({
               sqlQueryStatement: sqlQueryStatement,

--- a/application/backend/src/business/services/jobs/job-cloud-formation-create-service.ts
+++ b/application/backend/src/business/services/jobs/job-cloud-formation-create-service.ts
@@ -254,8 +254,11 @@ export class JobCloudFormationCreateService extends JobService {
           await this.awsAccessPointService.getInstalledAccessPointObjectMap(
             cloudFormationInstallJob.forRelease.releaseKey,
           );
+
         const apArn = new Set<string>(
-          Object.values(map).map((ape) => ape.objectStoreBucket),
+          Object.values(map)
+            .map((d) => d.accessPointArn)
+            .filter((d) => !!d) as string[],
         );
 
         // Append with existing one if any

--- a/application/backend/src/business/services/jobs/job-cloud-formation-create-service.ts
+++ b/application/backend/src/business/services/jobs/job-cloud-formation-create-service.ts
@@ -89,7 +89,9 @@ export class JobCloudFormationCreateService extends JobService {
           status: e.job.JobStatus.running,
           started: e.datetime_current(),
           percentDone: e.int16(0),
-          messages: e.literal(e.array(e.str), ["Created"]),
+          messages: e.literal(e.array(e.str), [
+            "Triggered install of stack in AWS",
+          ]),
           auditEntry: e
             .select(e.audit.ReleaseAuditEvent, (ae) => ({
               filter: e.op(ae.id, "=", e.uuid(newAuditEventId)),

--- a/application/backend/src/business/services/jobs/job-cloud-formation-create-service.ts
+++ b/application/backend/src/business/services/jobs/job-cloud-formation-create-service.ts
@@ -252,13 +252,13 @@ export class JobCloudFormationCreateService extends JobService {
           await this.awsAccessPointService.getInstalledAccessPointObjectMap(
             cloudFormationInstallJob.forRelease.releaseKey,
           );
-        const apAlias = new Set<string>(
+        const apArn = new Set<string>(
           Object.values(map).map((ape) => ape.objectStoreBucket),
         );
 
         // Append with existing one if any
         cloudFormationInstallJob?.forRelease?.activation?.accessPointArns?.forEach(
-          (alias) => apAlias.add(alias),
+          (alias) => apArn.add(alias),
         );
 
         await e
@@ -269,7 +269,7 @@ export class JobCloudFormationCreateService extends JobService {
               e.str(cloudFormationInstallJob.forRelease.releaseKey),
             ),
             set: {
-              accessPointArns: Array.from(apAlias),
+              accessPointArns: Array.from(apArn),
             },
           }))
           .run(this.edgeDbClient);

--- a/application/backend/src/business/services/manifests/manifest-bucket-key-types.ts
+++ b/application/backend/src/business/services/manifests/manifest-bucket-key-types.ts
@@ -19,6 +19,8 @@ export const ManifestBucketKeyObjectSchema = Type.Object({
   objectStoreBucket: Type.String(),
   objectStoreKey: Type.String(),
 
+  accessPointArn: Type.Optional(Type.String()),
+
   // optional fields depending on what type of access asked for
   objectStoreSigned: Type.Optional(Type.String()),
 

--- a/application/backend/src/business/services/releases/helpers/release-data-egress-helper.ts
+++ b/application/backend/src/business/services/releases/helpers/release-data-egress-helper.ts
@@ -10,7 +10,7 @@ import { IPLookupService } from "../../ip-lookup-service";
 export type ReleaseEgressRecords = {
   releaseKey: string;
   description: string;
-  auditId: string;
+  auditId?: string;
   egressId: string;
 
   occurredDateTime: Date;
@@ -38,7 +38,7 @@ export interface IQueryEgressRecordsProvider {
  */
 export const getLatestEgressRecordUpdate = async (
   tx: Transaction,
-  releaseKey: string
+  releaseKey: string,
 ): Promise<Date> => {
   const releaseDates = await e
     .select(e.release.Release, (r) => ({

--- a/application/backend/src/business/services/releases/release-activation-service.ts
+++ b/application/backend/src/business/services/releases/release-activation-service.ts
@@ -125,21 +125,21 @@ export class ReleaseActivationService extends ReleaseBaseService {
         if (releaseInfo.activation)
           throw new ReleaseActivationStateError(releaseKey);
 
-        // Do some checking if release is activatable
-        // 1. Check if there are any sharing configuration allowed for the release
-        // 2. Check if there are cases releasable with the specified cases and access control
-        //    are check within the 'createMasterManifest' function
-        if (
-          !releaseInfo.dataSharingConfiguration.objectSigningEnabled &&
-          !releaseInfo.dataSharingConfiguration.copyOutEnabled &&
-          !releaseInfo.dataSharingConfiguration.htsgetEnabled &&
-          !releaseInfo.dataSharingConfiguration.awsAccessPointEnabled &&
-          !releaseInfo.dataSharingConfiguration.gcpStorageIamEnabled
-        ) {
-          throw new ReleaseActivatedNothingError(
-            "No sharing configuration is enabled",
-          );
-        }
+        // // Do some checking if release is activatable
+        // // 1. Check if there are any sharing configuration allowed for the release
+        // // 2. Check if there are cases releasable with the specified cases and access control
+        // //    are check within the 'createMasterManifest' function
+        // if (
+        //   !releaseInfo.dataSharingConfiguration.objectSigningEnabled &&
+        //   !releaseInfo.dataSharingConfiguration.copyOutEnabled &&
+        //   !releaseInfo.dataSharingConfiguration.htsgetEnabled &&
+        //   !releaseInfo.dataSharingConfiguration.awsAccessPointEnabled &&
+        //   !releaseInfo.dataSharingConfiguration.gcpStorageIamEnabled
+        // ) {
+        //   throw new ReleaseActivatedNothingError(
+        //     "No sharing configuration is enabled",
+        //   );
+        // }
 
         const m = await this.manifestService.createMasterManifest(
           tx,

--- a/application/backend/src/business/services/releases/release-activation-service.ts
+++ b/application/backend/src/business/services/releases/release-activation-service.ts
@@ -125,21 +125,21 @@ export class ReleaseActivationService extends ReleaseBaseService {
         if (releaseInfo.activation)
           throw new ReleaseActivationStateError(releaseKey);
 
-        // // Do some checking if release is activatable
-        // // 1. Check if there are any sharing configuration allowed for the release
-        // // 2. Check if there are cases releasable with the specified cases and access control
-        // //    are check within the 'createMasterManifest' function
-        // if (
-        //   !releaseInfo.dataSharingConfiguration.objectSigningEnabled &&
-        //   !releaseInfo.dataSharingConfiguration.copyOutEnabled &&
-        //   !releaseInfo.dataSharingConfiguration.htsgetEnabled &&
-        //   !releaseInfo.dataSharingConfiguration.awsAccessPointEnabled &&
-        //   !releaseInfo.dataSharingConfiguration.gcpStorageIamEnabled
-        // ) {
-        //   throw new ReleaseActivatedNothingError(
-        //     "No sharing configuration is enabled",
-        //   );
-        // }
+        // Do some checking if release is activatable
+        // 1. Check if there are any sharing configuration allowed for the release
+        // 2. Check if there are cases releasable with the specified cases and access control
+        //    are check within the 'createMasterManifest' function
+        if (
+          !releaseInfo.dataSharingConfiguration.objectSigningEnabled &&
+          !releaseInfo.dataSharingConfiguration.copyOutEnabled &&
+          !releaseInfo.dataSharingConfiguration.htsgetEnabled &&
+          !releaseInfo.dataSharingConfiguration.awsAccessPointEnabled &&
+          !releaseInfo.dataSharingConfiguration.gcpStorageIamEnabled
+        ) {
+          throw new ReleaseActivatedNothingError(
+            "No sharing configuration is enabled",
+          );
+        }
 
         const m = await this.manifestService.createMasterManifest(
           tx,

--- a/application/backend/src/business/services/releases/release-activation-service.ts
+++ b/application/backend/src/business/services/releases/release-activation-service.ts
@@ -215,7 +215,6 @@ export class ReleaseActivationService extends ReleaseBaseService {
         }
       },
       async (tx, _) => {
-        console.log("trigger tx");
         const { releaseInfo } = await getReleaseInfo(tx, releaseKey);
 
         if (!releaseInfo) throw new ReleaseDisappearedError(releaseKey);

--- a/application/backend/src/business/services/releases/release-service.ts
+++ b/application/backend/src/business/services/releases/release-service.ts
@@ -57,7 +57,7 @@ export class ReleaseService extends ReleaseBaseService {
     @inject(UserService) userService: UserService,
     @inject(PermissionService) permissionService: PermissionService,
     @inject(UserData) private readonly userData: UserData,
-    @inject("CloudFormationClient") cfnClient: CloudFormationClient
+    @inject("CloudFormationClient") cfnClient: CloudFormationClient,
   ) {
     super(
       settings,
@@ -67,7 +67,7 @@ export class ReleaseService extends ReleaseBaseService {
       auditEventService,
       auditEventTimedService,
       permissionService,
-      cfnClient
+      cfnClient,
     );
   }
 
@@ -83,7 +83,7 @@ export class ReleaseService extends ReleaseBaseService {
   public async getAll(
     user: AuthenticatedUser,
     limit: number,
-    offset: number
+    offset: number,
   ): Promise<PagedResult<ReleaseSummaryType>> {
     const allReleasesByUser = await releaseGetAllByUser(this.edgeDbClient, {
       userDbId: user.dbId,
@@ -129,11 +129,11 @@ export class ReleaseService extends ReleaseBaseService {
    */
   public async get(
     user: AuthenticatedUser,
-    releaseKey: string
+    releaseKey: string,
   ): Promise<ReleaseDetailType | null> {
     const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
       user,
-      releaseKey
+      releaseKey,
     );
 
     await this.createReleaseViewAuditEvent(user, releaseKey);
@@ -149,7 +149,7 @@ export class ReleaseService extends ReleaseBaseService {
    */
   public async new(
     user: AuthenticatedUser,
-    release: ReleaseManualType
+    release: ReleaseManualType,
   ): Promise<string> {
     const dbUser = await this.userData.getDbUser(this.edgeDbClient, user);
 
@@ -158,11 +158,11 @@ export class ReleaseService extends ReleaseBaseService {
     const otherResearchers = splitUserEmails(release.applicantEmailAddresses);
 
     otherResearchers.forEach((r) =>
-      checkValidApplicationUser(r, "collaborator")
+      checkValidApplicationUser(r, "collaborator"),
     );
 
     const releaseKey = await getNextReleaseKey(
-      this.settings.releaseKeyPrefix
+      this.settings.releaseKeyPrefix,
     ).run(this.edgeDbClient);
 
     const releaseRow = await e
@@ -178,7 +178,7 @@ export class ReleaseService extends ReleaseBaseService {
 
 This application was manually created via Elsa Data on ${format(
           new Date(),
-          "dd/MM/yyyy"
+          "dd/MM/yyyy",
         )}.
 
 #### Summary
@@ -211,7 +211,7 @@ ${release.applicantEmailAddresses}
         isAllowedPhenotypeData: true,
         dataSharingConfiguration: e.insert(
           e.release.DataSharingConfiguration,
-          {}
+          {},
         ),
       })
       .run(this.edgeDbClient);
@@ -223,14 +223,14 @@ ${release.applicantEmailAddresses}
         r.role,
         releaseRow.id,
         releaseKey,
-        this.auditEventService
+        this.auditEventService,
       );
     }
 
     await this.userService.registerRoleInRelease(
       user,
       releaseKey,
-      "Administrator"
+      "Administrator",
     );
 
     return releaseKey;
@@ -246,11 +246,11 @@ ${release.applicantEmailAddresses}
    */
   public async getPassword(
     user: AuthenticatedUser,
-    releaseKey: string
+    releaseKey: string,
   ): Promise<string | null> {
     const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
       user,
-      releaseKey
+      releaseKey,
     );
 
     return await this.auditEventService.transactionalReadInReleaseAuditPattern(
@@ -270,7 +270,7 @@ ${release.applicantEmailAddresses}
       async (p) => {
         return p;
       },
-      true
+      true,
     );
   }
 
@@ -282,11 +282,11 @@ ${release.applicantEmailAddresses}
    */
   public async getIncrementingCounter(
     user: AuthenticatedUser,
-    releaseKey: string
+    releaseKey: string,
   ): Promise<number> {
     const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
       user,
-      releaseKey
+      releaseKey,
     );
 
     // this integer is actually global to the db - so we don't need specific
@@ -299,7 +299,7 @@ ${release.applicantEmailAddresses}
     user: AuthenticatedUser,
     releaseKey: string,
     system: string,
-    code: string
+    code: string,
   ): Promise<ReleaseDetailType> {
     return await this.alterApplicationCodedArrayEntry(
       user,
@@ -307,7 +307,7 @@ ${release.applicantEmailAddresses}
       "diseases",
       system,
       code,
-      false
+      false,
     );
   }
 
@@ -315,7 +315,7 @@ ${release.applicantEmailAddresses}
     user: AuthenticatedUser,
     releaseKey: string,
     system: string,
-    code: string
+    code: string,
   ): Promise<ReleaseDetailType> {
     return await this.alterApplicationCodedArrayEntry(
       user,
@@ -323,7 +323,7 @@ ${release.applicantEmailAddresses}
       "diseases",
       system,
       code,
-      true
+      true,
     );
   }
 
@@ -331,7 +331,7 @@ ${release.applicantEmailAddresses}
     user: AuthenticatedUser,
     releaseKey: string,
     system: string,
-    code: string
+    code: string,
   ): Promise<ReleaseDetailType> {
     return await this.alterApplicationCodedArrayEntry(
       user,
@@ -339,7 +339,7 @@ ${release.applicantEmailAddresses}
       "countries",
       system,
       code,
-      false
+      false,
     );
   }
 
@@ -347,7 +347,7 @@ ${release.applicantEmailAddresses}
     user: AuthenticatedUser,
     releaseKey: string,
     system: string,
-    code: string
+    code: string,
   ): Promise<ReleaseDetailType> {
     return await this.alterApplicationCodedArrayEntry(
       user,
@@ -355,18 +355,18 @@ ${release.applicantEmailAddresses}
       "countries",
       system,
       code,
-      true
+      true,
     );
   }
 
   public async setTypeOfApplicationCoded(
     user: AuthenticatedUser,
     releaseKey: string,
-    type: "HMB" | "DS" | "CC" | "GRU" | "POA"
+    type: "HMB" | "DS" | "CC" | "GRU" | "POA",
   ): Promise<ReleaseDetailType> {
     const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
       user,
-      releaseKey
+      releaseKey,
     );
 
     const actionDescription = "set application coded type";
@@ -400,7 +400,7 @@ ${release.applicantEmailAddresses}
             filter: e.op(
               ac.id,
               "=",
-              e.uuid(releaseWithAppCoded.applicationCoded.id)
+              e.uuid(releaseWithAppCoded.applicationCoded.id),
             ),
             set: {
               studyType: type,
@@ -414,14 +414,14 @@ ${release.applicantEmailAddresses}
       },
       async () => {
         return await this.getBase(releaseKey, userRole);
-      }
+      },
     );
   }
 
   public async setBeaconQuery(
     user: AuthenticatedUser,
     releaseKey: string,
-    query: any
+    query: any,
   ): Promise<ReleaseDetailType> {
     const { userRole, isActivated } =
       await this.getBoundaryInfoWithThrowOnFailure(user, releaseKey);
@@ -457,7 +457,7 @@ ${release.applicantEmailAddresses}
               filter: e.op(
                 ac.id,
                 "=",
-                e.uuid(releaseWithAppCoded.applicationCoded.id)
+                e.uuid(releaseWithAppCoded.applicationCoded.id),
               ),
               set: {
                 beaconQuery: query,
@@ -469,7 +469,7 @@ ${release.applicantEmailAddresses}
       },
       async () => {
         return await this.getBase(releaseKey, userRole);
-      }
+      },
     );
   }
 
@@ -495,7 +495,7 @@ ${release.applicantEmailAddresses}
       | "isAllowedS3Data"
       | "isAllowedGSData"
       | "isAllowedR2Data",
-    value: boolean
+    value: boolean,
   ): Promise<ReleaseDetailType> {
     const { userRole, isActivated } =
       await this.getBoundaryInfoWithThrowOnFailure(user, releaseKey);
@@ -549,7 +549,7 @@ ${release.applicantEmailAddresses}
       },
       async () => {
         return await this.getBase(releaseKey, userRole);
-      }
+      },
     );
   }
 
@@ -575,12 +575,10 @@ ${release.applicantEmailAddresses}
       | "/dataSharingConfiguration/awsAccessPointName"
       | "/dataSharingConfiguration/gcpStorageIamEnabled"
       | "/dataSharingConfiguration/gcpStorageIamUsers",
-    value: any
+    value: any,
   ): Promise<ReleaseDetailType> {
-    const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
-      user,
-      releaseKey
-    );
+    const { userRole, isActivated } =
+      await this.getBoundaryInfoWithThrowOnFailure(user, releaseKey);
 
     return await this.auditEventService.transactionalUpdateInReleaseAuditPattern(
       user,
@@ -663,7 +661,7 @@ ${release.applicantEmailAddresses}
             break;
           default:
             throw new Error(
-              `setDataSharingConfigurationField passed in unknown field type to set '${type}'`
+              `setDataSharingConfigurationField passed in unknown field type to set '${type}'`,
             );
         }
 
@@ -674,7 +672,7 @@ ${release.applicantEmailAddresses}
                 dsc["<dataSharingConfiguration[is release::Release]"]
                   .releaseKey,
                 "=",
-                releaseKey
+                releaseKey,
               ),
               set: fieldToSet,
             }))
@@ -688,7 +686,7 @@ ${release.applicantEmailAddresses}
       },
       async () => {
         return await this.getBase(releaseKey, userRole);
-      }
+      },
     );
   }
 
@@ -703,15 +701,15 @@ ${release.applicantEmailAddresses}
         userDbId: string;
         releaseKey: string;
         restriction: string;
-      }
-    ) => Promise<{ id: string } | null>
+      },
+    ) => Promise<{ id: string } | null>,
   ) {
     const { auditEventId, auditEventStart } = await auditReleaseUpdateStart(
       this.auditEventService,
       this.edgeDbClient,
       user,
       releaseKey,
-      actionDescription
+      actionDescription,
     );
 
     await this.edgeDbClient.transaction(async (tx) => {
@@ -726,7 +724,7 @@ ${release.applicantEmailAddresses}
         tx,
         auditEventId,
         auditEventStart,
-        { restriction }
+        { restriction },
       );
     });
   }
@@ -734,11 +732,11 @@ ${release.applicantEmailAddresses}
   public async applyHtsgetRestriction(
     user: AuthenticatedUser,
     releaseKey: string,
-    restriction: "CongenitalHeartDefect" | "Autism" | "Achromatopsia"
+    restriction: "CongenitalHeartDefect" | "Autism" | "Achromatopsia",
   ): Promise<ReleaseDetailType> {
     const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
       user,
-      releaseKey
+      releaseKey,
     );
 
     if (userRole != "Administrator")
@@ -751,7 +749,7 @@ ${release.applicantEmailAddresses}
         releaseKey,
         restriction,
         "Applied htsget restriction",
-        applyHtsgetRestriction
+        applyHtsgetRestriction,
       );
     }
 
@@ -761,11 +759,11 @@ ${release.applicantEmailAddresses}
   public async removeHtsgetRestriction(
     user: AuthenticatedUser,
     releaseKey: string,
-    restriction: "CongenitalHeartDefect" | "Autism" | "Achromatopsia"
+    restriction: "CongenitalHeartDefect" | "Autism" | "Achromatopsia",
   ): Promise<ReleaseDetailType> {
     const { userRole } = await this.getBoundaryInfoWithThrowOnFailure(
       user,
-      releaseKey
+      releaseKey,
     );
 
     if (userRole != "Administrator")
@@ -778,7 +776,7 @@ ${release.applicantEmailAddresses}
         releaseKey,
         restriction,
         "Removed htsget restriction",
-        removeHtsgetRestriction
+        removeHtsgetRestriction,
       );
     }
 

--- a/application/backend/src/business/services/releases/release-service.ts
+++ b/application/backend/src/business/services/releases/release-service.ts
@@ -645,6 +645,7 @@ ${release.applicantEmailAddresses}
             };
             break;
           case "/dataSharingConfiguration/awsAccessPointName":
+            // Check if active AP -> don't allow to change this?
             fieldToSet = {
               awsAccessPointName: e.str(value),
             };

--- a/application/backend/src/business/services/sharers/aws-access-point/_access-point-template-helper.ts
+++ b/application/backend/src/business/services/sharers/aws-access-point/_access-point-template-helper.ts
@@ -19,7 +19,7 @@ export type AccessPointTemplateToSave = {
 // for access point work we are only interested in the following fields of our manifest objects
 export type AccessPointEntry = Pick<
   ManifestBucketKeyObjectType,
-  "objectStoreUrl" | "objectStoreBucket" | "objectStoreKey"
+  "objectStoreUrl" | "objectStoreBucket" | "objectStoreKey" | "accessPointArn"
 > & {
   accessPointUnique?: string;
 };
@@ -57,7 +57,7 @@ const ACCESS_POINTS_PER_STACK = 30;
  */
 export async function correctAccessPointUrls(
   stack: Stack,
-  accountId: string
+  accountId: string,
 ): Promise<Record<string, AccessPointEntry>> {
   if (!stack.Outputs) {
     return {};
@@ -66,7 +66,11 @@ export async function correctAccessPointUrls(
   const STACK_OUTPUT_VALUE_REGEX = new RegExp("^([^:]+):([^:]+):(.+)$");
 
   const POLICY_RESOURCE_REGEX = new RegExp(
-    "^([^:]+):([^:]+):([^:]+):([^:]+):([^:]+):accesspoint/([^/]+)/object/(.*)\\*$"
+    "^([^:]+):([^:]+):([^:]+):([^:]+):([^:]+):accesspoint/([^/]+)/object/(.*)\\*$",
+  );
+
+  const ACCESS_POINT_ARN_REGEX = new RegExp(
+    "^arn:aws:s3:[a-z0-9-]+:[0-9]+:accesspoint/[a-zA-Z0-9_-]+",
   );
 
   const s3ControlClient = new S3ControlClient({});
@@ -93,7 +97,7 @@ export async function correctAccessPointUrls(
       new GetAccessPointPolicyCommand({
         AccountId: accountId,
         Name: accessPointName,
-      })
+      }),
     );
 
     if (policyResult.Policy) {
@@ -110,6 +114,7 @@ export async function correctAccessPointUrls(
         if (stmt["Action"] === "s3:GetObject") {
           for (const res of stmt["Resource"] ?? []) {
             const match = res.match(POLICY_RESOURCE_REGEX);
+            const apArnMatch = res.match(ACCESS_POINT_ARN_REGEX);
             if (match) {
               const originalS3 = `s3://${accessPointBucket}/${match[7]}`;
 
@@ -117,6 +122,7 @@ export async function correctAccessPointUrls(
                 objectStoreUrl: `s3://${accessPointAlias}/${match[7]}`,
                 objectStoreBucket: accessPointAlias,
                 objectStoreKey: match[7],
+                accessPointArn: apArnMatch,
               };
             }
           }
@@ -161,7 +167,7 @@ function chunkIntoBiteSizes(files: ManifestBucketKeyObjectType[]) {
   // split out into groups by bucket
   const filesByBucket = groupBy(
     Object.values(uniqueEntries),
-    "objectStoreBucket"
+    "objectStoreBucket",
   );
 
   // each access points can only wrap a single bucket and is size limited to a policy
@@ -177,7 +183,7 @@ function chunkIntoBiteSizes(files: ManifestBucketKeyObjectType[]) {
 
       if (unique in filesByGroup) {
         throw new Error(
-          "We got incredibly unlucky in that we generated an identical 8 byte random number"
+          "We got incredibly unlucky in that we generated an identical 8 byte random number",
         );
       }
 
@@ -211,7 +217,7 @@ function createAccessPointResourceForCloudFormation(
   groupUnique: string,
   groupObjects: AccessPointEntry[],
   shareToAccountIds: string[],
-  shareToVpcId?: string
+  shareToVpcId?: string,
 ) {
   if (groupObjects.length === 0)
     throw new Error("Can't create an access point with no objects");
@@ -287,7 +293,7 @@ export function createAccessPointTemplateFromObjects(
   releaseKey: string,
   objects: ManifestBucketKeyObjectType[],
   shareToAccountIds: string[],
-  shareToVpcId?: string
+  shareToVpcId?: string,
 ): AccessPointTemplateToSave[] {
   const rootTemplateName = "install.template";
 
@@ -299,7 +305,7 @@ export function createAccessPointTemplateFromObjects(
 
   if (isEmpty(objectGroups))
     throw new Error(
-      "Cannot create an access point template if there are no objects"
+      "Cannot create an access point template if there are no objects",
     );
 
   // for the S3 paths of the resulting templates - we want to make sure every time we do this it is in someway unique
@@ -411,7 +417,7 @@ export function createAccessPointTemplateFromObjects(
         groupUnique,
         groupObjects,
         shareToAccountIds,
-        shareToVpcId
+        shareToVpcId,
       );
 
     // from each stack we share outputs of each access point Alias and name and bucket

--- a/application/backend/src/business/services/sharers/aws-access-point/_access-point-template-helper.ts
+++ b/application/backend/src/business/services/sharers/aws-access-point/_access-point-template-helper.ts
@@ -122,7 +122,7 @@ export async function correctAccessPointUrls(
                 objectStoreUrl: `s3://${accessPointAlias}/${match[7]}`,
                 objectStoreBucket: accessPointAlias,
                 objectStoreKey: match[7],
-                accessPointArn: apArnMatch,
+                accessPointArn: apArnMatch ? apArnMatch[0] : undefined,
               };
             }
           }

--- a/application/backend/src/test-data/release/insert-test-data-release1.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release1.ts
@@ -94,6 +94,10 @@ export async function insertRelease1(
         activatedByDisplayName: releaseAdministrator[0].name,
         manifest: e.json({}),
         manifestEtag: "123456",
+        accessPointArns: [
+          "third-access-point-s3alias",
+          "second-access-point-s3alias",
+        ],
       }),
       previouslyActivated: e.set(
         e.insert(e.release.Activation, {
@@ -102,6 +106,10 @@ export async function insertRelease1(
           activatedByDisplayName: releaseAdministrator[0].name,
           manifest: e.json({}),
           manifestEtag: "abcdef",
+          accessPointArns: [
+            "first-access-point-s3alias",
+            "second-access-point-s3alias",
+          ],
         }),
       ),
       dataSharingConfiguration: e.insert(e.release.DataSharingConfiguration, {

--- a/application/backend/src/test-data/release/insert-test-data-release1.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release1.ts
@@ -95,8 +95,8 @@ export async function insertRelease1(
         manifest: e.json({}),
         manifestEtag: "123456",
         accessPointArns: [
-          "third-access-point-s3alias",
-          "second-access-point-s3alias",
+          "arn:aws:s3:ap-southeast-2:123456789012:accesspoint/test2",
+          "arn:aws:s3:ap-southeast-2:123456789012:accesspoint/test3",
         ],
       }),
       previouslyActivated: e.set(
@@ -107,8 +107,8 @@ export async function insertRelease1(
           manifest: e.json({}),
           manifestEtag: "abcdef",
           accessPointArns: [
-            "first-access-point-s3alias",
-            "second-access-point-s3alias",
+            "arn:aws:s3:ap-southeast-2:123456789012:accesspoint/test1",
+            "arn:aws:s3:ap-southeast-2:123456789012:accesspoint/test2",
           ],
         }),
       ),

--- a/application/backend/src/test-data/release/insert-test-data-release3.ts
+++ b/application/backend/src/test-data/release/insert-test-data-release3.ts
@@ -11,7 +11,7 @@ export const RELEASE3_RELEASE_IDENTIFIER = "R003";
 
 export async function insertRelease3(
   dc: DependencyContainer,
-  releaseProps: InsertReleaseProps
+  releaseProps: InsertReleaseProps,
 ) {
   const { edgeDbClient } = getServices(dc);
   const { releaseAdministrator, releaseManager, releaseMember, datasetUris } =
@@ -54,10 +54,9 @@ export async function insertRelease3(
       datasetUris: e.array([
         "urn:fdc:australiangenomics.org.au:2022:dataset/cardiac",
       ]),
-      dataSharingConfiguration: e.insert(
-        e.release.DataSharingConfiguration,
-        {}
-      ),
+      dataSharingConfiguration: e.insert(e.release.DataSharingConfiguration, {
+        objectSigningEnabled: true,
+      }),
       datasetCaseUrisOrderPreference: [""],
       datasetSpecimenUrisOrderPreference: [""],
       datasetIndividualUrisOrderPreference: [""],
@@ -76,7 +75,7 @@ export async function insertRelease3(
           whoId: "a",
           occurredDateTime: e.datetime_current(),
           inProgress: false,
-        })
+        }),
       ),
     })
     .run(edgeDbClient);
@@ -87,7 +86,7 @@ export async function insertRelease3(
       insertRelease3.id,
       user.email,
       "Administrator",
-      edgeDbClient
+      edgeDbClient,
     );
   }
   for (const user of releaseManager) {

--- a/application/backend/tests/service-tests/aws/aws-cloudtrail-lake.test.ts
+++ b/application/backend/tests/service-tests/aws/aws-cloudtrail-lake.test.ts
@@ -12,6 +12,7 @@ import { AwsCloudTrailLakeService } from "../../../src/business/services/aws/aws
 import { AwsEnabledServiceMock } from "../client-mocks";
 import { IPLookupService } from "../../../src/business/services/ip-lookup-service";
 import { AwsAccessPointService } from "../../../src/business/services/sharers/aws-access-point/aws-access-point-service";
+import { isEqual } from "lodash";
 
 const testContainer = registerTypes();
 
@@ -48,7 +49,7 @@ describe("Test CloudTrailLake Service", () => {
     const accessPointService = testContainer.resolve(AwsAccessPointService);
     const BUCKET_NAME = "umccr-10g-data-dev";
     const KEY = "HG00096/HG00096.hard-filtered.vcf.gz";
-    const mockData = [
+    const cloudtrailPresignMockData = [
       {
         eventTime: "2022-10-24 05:56:40.000",
         sourceIPAddress: "192.19.192.192",
@@ -56,6 +57,16 @@ describe("Test CloudTrailLake Service", () => {
         key: KEY,
         bytesTransferredOut: "101.0",
         auditId: "abcd-defg-hijk-lmno",
+        eventId: "1234-5678-1234-5678",
+      },
+    ];
+    const cloudtrailAPMockData = [
+      {
+        eventTime: "2022-10-24 05:56:40.000",
+        sourceIPAddress: "192.19.192.192",
+        bucketName: BUCKET_NAME,
+        key: KEY,
+        bytesTransferredOut: "101.0",
         eventId: "1234-5678-1234-5678",
       },
     ];
@@ -72,13 +83,19 @@ describe("Test CloudTrailLake Service", () => {
 
     jest
       .spyOn(awsCloudTrailLakeService, "queryCloudTrailLake")
-      .mockImplementation(async () => mockData);
-
-    // we need to make sure the access point service doesn't actually hit real AWS
-    // so mock out the implementation to be empty map
-    jest
-      .spyOn(accessPointService, "getInstalledAccessPointObjectMap")
-      .mockImplementation(async (releaseKey: string) => ({}));
+      .mockImplementation(
+        async (input: {
+          sqlQueryStatement: string;
+          eventDataStoreId: string;
+        }) => {
+          if (input.sqlQueryStatement.includes("AWS::S3::AccessPoint")) {
+            return cloudtrailAPMockData;
+          } else {
+            // A presigned mock data
+            return cloudtrailPresignMockData;
+          }
+        },
+      );
 
     const egressRecords = await awsCloudTrailLakeService.getNewEgressRecords({
       releaseKey: testReleaseKey,
@@ -86,17 +103,39 @@ describe("Test CloudTrailLake Service", () => {
       currentDate: new Date(),
     });
 
-    expect(egressRecords.length).toBe(1);
-    expect(egressRecords[0]).toStrictEqual({
-      releaseKey: "TESTRELEASE0001",
-      description: "Accessed via presigned url.",
-      auditId: "abcd-defg-hijk-lmno",
-      egressId: "1234-5678-1234-5678",
-      occurredDateTime: new Date("2022-10-24T05:56:40.000Z"),
-      sourceIpAddress: "192.19.192.192",
-      egressBytes: 101,
-      fileUrl: "s3://umccr-10g-data-dev/HG00096/HG00096.hard-filtered.vcf.gz",
-    });
+    // TODO: more testing that also include AccessPoint
+    expect(egressRecords.length).toBe(2);
+    expect(
+      egressRecords.find((v) =>
+        isEqual(v, {
+          releaseKey: "TESTRELEASE0001",
+          description: "Accessed via presigned url.",
+          auditId: "abcd-defg-hijk-lmno",
+          egressId: "1234-5678-1234-5678",
+          occurredDateTime: new Date("2022-10-24T05:56:40.000Z"),
+          sourceIpAddress: "192.19.192.192",
+          egressBytes: 101,
+          fileUrl:
+            "s3://umccr-10g-data-dev/HG00096/HG00096.hard-filtered.vcf.gz",
+        }),
+      ),
+    ).toBeTruthy();
+    expect(
+      egressRecords.find((v) =>
+        isEqual(v, {
+          releaseKey: "TESTRELEASE0001",
+          description: "Accessed via S3 access point.",
+          // access point cannot have auditId embedded in the request query
+          auditId: undefined,
+          egressId: "1234-5678-1234-5678",
+          occurredDateTime: new Date("2022-10-24T05:56:40.000Z"),
+          sourceIpAddress: "192.19.192.192",
+          egressBytes: 101,
+          fileUrl:
+            "s3://umccr-10g-data-dev/HG00096/HG00096.hard-filtered.vcf.gz",
+        }),
+      ),
+    ).toBeTruthy();
   });
 
   it("Test getEventDataStoreIdFromReleaseKey", async () => {

--- a/application/backend/tests/service-tests/aws/aws-cloudtrail-lake.test.ts
+++ b/application/backend/tests/service-tests/aws/aws-cloudtrail-lake.test.ts
@@ -43,7 +43,7 @@ describe("Test CloudTrailLake Service", () => {
 
   it("Test queryCloudTrailLake", async () => {
     const awsCloudTrailLakeService = testContainer.resolve(
-      AwsCloudTrailLakeService
+      AwsCloudTrailLakeService,
     );
     const accessPointService = testContainer.resolve(AwsAccessPointService);
     const BUCKET_NAME = "umccr-10g-data-dev";
@@ -55,7 +55,6 @@ describe("Test CloudTrailLake Service", () => {
         bucketName: BUCKET_NAME,
         key: KEY,
         bytesTransferredOut: "101.0",
-        releaseKey: testReleaseKey,
         auditId: "abcd-defg-hijk-lmno",
         eventId: "1234-5678-1234-5678",
       },
@@ -102,7 +101,7 @@ describe("Test CloudTrailLake Service", () => {
 
   it("Test getEventDataStoreIdFromReleaseKey", async () => {
     const awsCloudTrailLakeService = testContainer.resolve(
-      AwsCloudTrailLakeService
+      AwsCloudTrailLakeService,
     );
 
     const eventDataStoreIdArr =

--- a/application/backend/tests/service-tests/commons/releases.common.ts
+++ b/application/backend/tests/service-tests/commons/releases.common.ts
@@ -76,11 +76,11 @@ export async function beforeEachCommon(dc: DependencyContainer) {
         findSpecimenQuery("HG03433"),
         findSpecimenQuery(BART_SPECIMEN),
         findSpecimenQuery(HOMER_SPECIMEN),
-        findSpecimenQuery(JUDY_SPECIMEN)
+        findSpecimenQuery(JUDY_SPECIMEN),
       ),
       dataSharingConfiguration: e.insert(
         e.release.DataSharingConfiguration,
-        {}
+        {},
       ),
       releaseAuditLog: e.set(
         e.insert(e.audit.ReleaseAuditEvent, {
@@ -91,7 +91,7 @@ export async function beforeEachCommon(dc: DependencyContainer) {
           whoId: "a",
           occurredDateTime: e.datetime_current(),
           inProgress: false,
-        })
+        }),
       ),
       lastDataEgressQueryTimestamp: e.datetime_current(),
     })
@@ -168,6 +168,23 @@ export async function beforeEachCommon(dc: DependencyContainer) {
       displayName: allowedDisplayName,
       email: allowedEmail,
     });
+
+    // Activating the release by this admin
+    await e
+      .update(e.release.Release, (r) => ({
+        filter: e.op(r.releaseKey, "=", testReleaseKey),
+        set: {
+          activation: e.insert(e.release.Activation, {
+            activatedAt: e.datetime(new Date(2022, 9, 12, 4, 2, 5)),
+            activatedById: "http://superAdminUser.com",
+            activatedByDisplayName: "Test User Who Is a SuperAdmin Access",
+            manifest: e.json({}),
+            manifestEtag: "123456",
+            accessPointArns: ["first-access-point-s3alias"],
+          }),
+        },
+      }))
+      .run(edgeDbClient);
   }
 
   // Manager user has limits to read/write and only visibility of released data items

--- a/application/backend/tests/service-tests/commons/releases.common.ts
+++ b/application/backend/tests/service-tests/commons/releases.common.ts
@@ -78,10 +78,9 @@ export async function beforeEachCommon(dc: DependencyContainer) {
         findSpecimenQuery(HOMER_SPECIMEN),
         findSpecimenQuery(JUDY_SPECIMEN),
       ),
-      dataSharingConfiguration: e.insert(
-        e.release.DataSharingConfiguration,
-        {},
-      ),
+      dataSharingConfiguration: e.insert(e.release.DataSharingConfiguration, {
+        objectSigningEnabled: true,
+      }),
       releaseAuditLog: e.set(
         e.insert(e.audit.ReleaseAuditEvent, {
           actionCategory: "C",
@@ -169,19 +168,23 @@ export async function beforeEachCommon(dc: DependencyContainer) {
       email: allowedEmail,
     });
 
-    // Activating the release by this admin
+    // Adding an activation history to the release by this admin
     await e
       .update(e.release.Release, (r) => ({
         filter: e.op(r.releaseKey, "=", testReleaseKey),
         set: {
-          activation: e.insert(e.release.Activation, {
-            activatedAt: e.datetime(new Date(2022, 9, 12, 4, 2, 5)),
-            activatedById: "http://superAdminUser.com",
-            activatedByDisplayName: "Test User Who Is a SuperAdmin Access",
-            manifest: e.json({}),
-            manifestEtag: "123456",
-            accessPointArns: ["first-access-point-s3alias"],
-          }),
+          previouslyActivated: e.set(
+            e.insert(e.release.Activation, {
+              activatedAt: e.datetime(new Date(2022, 9, 12, 4, 2, 5)),
+              activatedById: "http://superAdminUser.com",
+              activatedByDisplayName: "Test User Who Is a SuperAdmin Access",
+              manifest: e.json({}),
+              manifestEtag: "123456",
+              accessPointArns: [
+                "arn:aws:s3:ap-southeast-2:123456789012:accesspoint/test1",
+              ],
+            }),
+          ),
         },
       }))
       .run(edgeDbClient);

--- a/application/backend/tests/service-tests/releases/releases.activation.test.ts
+++ b/application/backend/tests/service-tests/releases/releases.activation.test.ts
@@ -39,7 +39,7 @@ beforeEach(async () => {
 it("releases can be activated", async () => {
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
 
   const result = await releaseService.get(superAdminUser, testReleaseKey);
@@ -48,14 +48,14 @@ it("releases can be activated", async () => {
   assert(result != null);
   expect(result.activation).toBeDefined();
   expect(result.activation!.activatedByDisplayName).toBe(
-    "Test User Who Is a SuperAdmin Access"
+    "Test User Who Is a SuperAdmin Access",
   );
 });
 
 it("active releases have a manifest", async () => {
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
 
   const result = await manifestService.getActiveManifest(testReleaseKey);
@@ -74,23 +74,23 @@ it("active releases have a manifest", async () => {
 it("releases that are active can't be activated again", async () => {
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
 
   await expect(
-    releaseActivationService.activateRelease(superAdminUser, testReleaseKey)
+    releaseActivationService.activateRelease(superAdminUser, testReleaseKey),
   ).rejects.toThrow(ReleaseActivationStateError);
 });
 
 it("releases can be deactivated", async () => {
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
 
   await releaseActivationService.deactivateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
 
   const result = await releaseService.get(superAdminUser, testReleaseKey);
@@ -102,34 +102,37 @@ it("releases can be deactivated", async () => {
 
 it("deactivation only works when activated", async () => {
   await expect(
-    releaseActivationService.deactivateRelease(superAdminUser, testReleaseKey)
+    releaseActivationService.deactivateRelease(superAdminUser, testReleaseKey),
   ).rejects.toThrow(ReleaseDeactivationStateError);
 });
 
 it("deactivation creates a history of activations", async () => {
+  // Before each common has an existing previous activation history
+  // So adding +1 from the number of activation below
+
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
   await releaseActivationService.deactivateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
   await releaseActivationService.deactivateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
   await releaseActivationService.activateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
   await releaseActivationService.deactivateRelease(
     superAdminUser,
-    testReleaseKey
+    testReleaseKey,
   );
 
   // for the moment we can only check the history direct in the db
@@ -144,5 +147,5 @@ it("deactivation creates a history of activations", async () => {
   assert(r != null);
 
   expect(r.activation).toBeNull();
-  expect(r.previouslyActivated).toHaveLength(3);
+  expect(r.previouslyActivated).toHaveLength(4);
 });

--- a/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
+++ b/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
@@ -83,23 +83,26 @@ export const AwsAccessPointAccordionContent: React.FC<
 
   const isInstallDisabledDescriptions = new Set<string>();
   const isUninstallDisabledDescription = new Set<string>();
+  const isVPCOptionDisabledDescription = new Set<string>();
 
   if (isCurrentlyMissingNeededValues) {
     const m = "missing needed configuration values";
     isInstallDisabledDescriptions.add(m);
-    isUninstallDisabledDescription.add(m);
+    // isUninstallDisabledDescription.add(m);
   }
 
   if (isCurrentlyRunningAnotherJob) {
     const m = "currently running another job";
     isInstallDisabledDescriptions.add(m);
     isUninstallDisabledDescription.add(m);
+    isVPCOptionDisabledDescription.add(m);
   }
 
   if (isCurrentlyMutating) {
     const m = "currently in a mutation operation";
     isInstallDisabledDescriptions.add(m);
     isUninstallDisabledDescription.add(m);
+    isVPCOptionDisabledDescription.add(m);
   }
 
   if (isCurrentlyInactiveRelease) {
@@ -110,6 +113,9 @@ export const AwsAccessPointAccordionContent: React.FC<
     isInstallDisabledDescriptions.add(
       "an access point for this release is already installed",
     );
+    isVPCOptionDisabledDescription.add(
+      "options can be selected when there is no active access point installed",
+    );
   } else {
     isUninstallDisabledDescription.add(
       "there is no installed access point for this release",
@@ -117,9 +123,8 @@ export const AwsAccessPointAccordionContent: React.FC<
   }
 
   const isInstallDisabled = isInstallDisabledDescriptions.size > 0;
-  console.log("isInstallDisabledDescriptions", isInstallDisabledDescriptions);
   const isUninstallDisabled = isUninstallDisabledDescription.size > 0;
-  console.log("isUninstallDisabledDescription", isUninstallDisabledDescription);
+  const isVPCOptionDisabled = isVPCOptionDisabledDescription.size > 0;
 
   const error =
     accessPointInstallTriggerMutate.error ??
@@ -143,13 +148,8 @@ export const AwsAccessPointAccordionContent: React.FC<
         </label>
         <select
           className="input-bordered input w-full"
-          defaultValue={
+          value={
             props.releaseData?.dataSharingAwsAccessPoint?.name || NONE_DISPLAY
-          }
-          disabled={
-            props.releasePatchMutator.isLoading ||
-            // Not allowing to choose other AP when one is already installed
-            isCurrentlyAlreadyInstalled
           }
           onChange={(e) => {
             // we make sure we are only changing to a name that exists in our config
@@ -172,15 +172,24 @@ export const AwsAccessPointAccordionContent: React.FC<
             }
           }}
         >
-          <option key="none" value={""}>
+          <option key="none" value={""} disabled={isVPCOptionDisabled}>
             {NONE_DISPLAY}
           </option>
           {Object.entries(props.awsAccessPointSetting.allowedVpcs).map(
             (entry, index) => (
-              <option key={index}>{entry[0]}</option>
+              <option key={index} disabled={isVPCOptionDisabled}>
+                {entry[0]}
+              </option>
             ),
           )}
         </select>
+        {isVPCOptionDisabled && (
+          <span className="label-text-alt h-4 text-slate-400 mt-2">
+            {`(Disabled: ${Array.from(
+              isVPCOptionDisabledDescription.values(),
+            ).join(", ")})`}
+          </span>
+        )}
         <div className="form-control flex-grow">
           <label className="label">
             <span className="label-text">Account Id</span>
@@ -229,6 +238,14 @@ export const AwsAccessPointAccordionContent: React.FC<
         >
           Install
         </button>
+
+        {isInstallDisabled && (
+          <span className="label-text-alt h-4 text-slate-400 mt-2">
+            {`(Disabled: ${Array.from(
+              isInstallDisabledDescriptions.values(),
+            ).join(", ")})`}
+          </span>
+        )}
       </div>
       <div className="form-control">
         <label className="label">
@@ -253,6 +270,13 @@ export const AwsAccessPointAccordionContent: React.FC<
         >
           Uninstall
         </button>
+        {isUninstallDisabled && (
+          <span className="label-text-alt h-4 text-slate-400 mt-2">
+            {`(Disabled: ${Array.from(
+              isUninstallDisabledDescription.values(),
+            ).join(", ")})`}
+          </span>
+        )}
       </div>
     </>
   );

--- a/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
+++ b/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
@@ -184,7 +184,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           )}
         </select>
         {isVPCOptionDisabled && (
-          <span className="label-text-alt h-4 text-slate-400 mt-2">
+          <span className="label-text-alt text-slate-400 mt-2">
             {`(Disabled: ${Array.from(
               isVPCOptionDisabledDescription.values(),
             ).join(", ")})`}
@@ -240,7 +240,7 @@ export const AwsAccessPointAccordionContent: React.FC<
         </button>
 
         {isInstallDisabled && (
-          <span className="label-text-alt h-4 text-slate-400 mt-2">
+          <span className="label-text-alt text-slate-400 mt-2">
             {`(Disabled: ${Array.from(
               isInstallDisabledDescriptions.values(),
             ).join(", ")})`}
@@ -271,7 +271,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           Uninstall
         </button>
         {isUninstallDisabled && (
-          <span className="label-text-alt h-4 text-slate-400 mt-2">
+          <span className="label-text-alt text-slate-400 mt-2">
             {`(Disabled: ${Array.from(
               isUninstallDisabledDescription.values(),
             ).join(", ")})`}

--- a/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
+++ b/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
@@ -108,16 +108,18 @@ export const AwsAccessPointAccordionContent: React.FC<
 
   if (isCurrentlyAlreadyInstalled) {
     isInstallDisabledDescriptions.add(
-      "an access point for this release is already installed"
+      "an access point for this release is already installed",
     );
   } else {
     isUninstallDisabledDescription.add(
-      "there is no installed access point for this release"
+      "there is no installed access point for this release",
     );
   }
 
   const isInstallDisabled = isInstallDisabledDescriptions.size > 0;
+  console.log("isInstallDisabledDescriptions", isInstallDisabledDescriptions);
   const isUninstallDisabled = isUninstallDisabledDescription.size > 0;
+  console.log("isUninstallDisabledDescription", isUninstallDisabledDescription);
 
   const error =
     accessPointInstallTriggerMutate.error ??
@@ -144,11 +146,15 @@ export const AwsAccessPointAccordionContent: React.FC<
           defaultValue={
             props.releaseData?.dataSharingAwsAccessPoint?.name || NONE_DISPLAY
           }
-          disabled={props.releasePatchMutator.isLoading}
+          disabled={
+            props.releasePatchMutator.isLoading ||
+            // Not allowing to choose other AP when one is already installed
+            isCurrentlyAlreadyInstalled
+          }
           onChange={(e) => {
             // we make sure we are only changing to a name that exists in our config
             const newName = Object.keys(
-              props.awsAccessPointSetting.allowedVpcs
+              props.awsAccessPointSetting.allowedVpcs,
             ).find((name) => name === e.target.value);
 
             if (newName) {
@@ -172,7 +178,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           {Object.entries(props.awsAccessPointSetting.allowedVpcs).map(
             (entry, index) => (
               <option key={index}>{entry[0]}</option>
-            )
+            ),
           )}
         </select>
         <div className="form-control flex-grow">
@@ -216,7 +222,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           title={
             isInstallDisabled
               ? `Disabled due to\n${Array.from(
-                  isInstallDisabledDescriptions.values()
+                  isInstallDisabledDescriptions.values(),
                 ).join("\n")}`
               : undefined
           }
@@ -240,7 +246,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           title={
             isUninstallDisabled
               ? `Disabled due to\n${Array.from(
-                  isUninstallDisabledDescription.values()
+                  isUninstallDisabledDescription.values(),
                 ).join("\n")}`
               : undefined
           }

--- a/application/frontend/src/pages/releases/detail/sharer-control-box/sharer-control-box.tsx
+++ b/application/frontend/src/pages/releases/detail/sharer-control-box/sharer-control-box.tsx
@@ -52,18 +52,18 @@ export const SharerControlBox: React.FC<Props> = ({
         await utils.release.getSpecificRelease.invalidate({
           releaseKey: releaseKey,
         }),
-    }
+    },
   );
 
   // the settings come from the backend on login and tell us what is fundamentally enabled
   // in the system
   const objectSigningSetting = sharers.find(
-    isDiscriminate("type", "object-signing")
+    isDiscriminate("type", "object-signing"),
   );
   const copyOutSetting = sharers.find(isDiscriminate("type", "copy-out"));
   const htsgetSetting = sharers.find(isDiscriminate("type", "htsget"));
   const awsAccessPointSetting = sharers.find(
-    isDiscriminate("type", "aws-access-point")
+    isDiscriminate("type", "aws-access-point"),
   );
 
   // the "enabled" fields are whether the custodian has checked the checkbox..
@@ -73,7 +73,7 @@ export const SharerControlBox: React.FC<Props> = ({
   const awsAccessPointEnabled = !!releaseData.dataSharingAwsAccessPoint;
   // const gcpStorageIamEnabled = !!releaseData.dataSharingGcpStorageIam;
 
-  const error = releasePatchMutate.error;
+  const error = (releasePatchMutate.error as any)?.response?.data;
   const isError = releasePatchMutate.isError;
 
   return (

--- a/application/frontend/src/pages/releases/releases-master-page.tsx
+++ b/application/frontend/src/pages/releases/releases-master-page.tsx
@@ -64,14 +64,21 @@ export const ReleasesMasterPage: React.FC = () => {
   // *only* when running a job in the background - we want to set up a polling loop of the backend
   // so we set this effect up with a dependency on the runningJob field - and switch the
   // interval on only when there is background job
+
   useEffect(() => {
-    const interval = setInterval(async () => {
-      if (releaseQuery?.data?.runningJob) {
+    let interval: NodeJS.Timer | undefined = undefined;
+    if (releaseQuery?.data?.runningJob) {
+      interval = setInterval(async () => {
         await utils.release.getSpecificRelease.invalidate();
-      } else {
+      }, REFRESH_JOB_STATUS_MS);
+    } else {
+      const invalidateAllQuery = async () => {
         await queryClient.invalidateQueries();
-      }
-    }, REFRESH_JOB_STATUS_MS);
+      };
+      clearInterval(interval);
+      invalidateAllQuery();
+    }
+
     return () => {
       clearInterval(interval);
     };

--- a/application/frontend/src/pages/releases/releases-master-page.tsx
+++ b/application/frontend/src/pages/releases/releases-master-page.tsx
@@ -127,6 +127,13 @@ export const ReleasesMasterPage: React.FC = () => {
                      administrator - so this section will only appear for admins */}
             {releaseQuery.data.runningJob && (
               <Box heading="Background Job">
+                <div className="flex justify-start text-gray-500">
+                  <span className="text-sm font-medium">
+                    {`Message: ${releaseQuery.data.runningJob.messages.slice(
+                      -1,
+                    )}`}
+                  </span>
+                </div>
                 <div className="mb-4 flex justify-between">
                   <span className="text-base font-medium text-blue-700">
                     Running

--- a/e2e/tests/superAdmin/dac-manual-release.spec.ts
+++ b/e2e/tests/superAdmin/dac-manual-release.spec.ts
@@ -45,13 +45,13 @@ test("A release can be created manually which has selectable cases", async ({
   });
 
   await expect(
-    page.getByText("urn:fdc:umccr.org:2022:dataset/10c")
+    page.getByText("urn:fdc:umccr.org:2022:dataset/10c"),
   ).toBeVisible();
   await expect(
-    page.getByText("urn:fdc:umccr.org:2022:dataset/10f")
+    page.getByText("urn:fdc:umccr.org:2022:dataset/10f"),
   ).toBeVisible();
   await expect(
-    page.getByText("urn:fdc:umccr.org:2022:dataset/10g")
+    page.getByText("urn:fdc:umccr.org:2022:dataset/10g"),
   ).toBeVisible();
 
   // Press 'See details of application'
@@ -113,11 +113,25 @@ test("A release can be created manually which has selectable cases", async ({
       .toBeTruthy();
   }
 
+  // we need to enable at least 1 sharing configuration
+  {
+    const objectSigningCheckbox = page.getByText("Object Signing");
+
+    // expected to start false (this could easily change if we change the logic so don't be surprised if
+    // it fails here and we instead change the test)
+    expect(await objectSigningCheckbox.isChecked()).toBeFalsy();
+
+    await objectSigningCheckbox.click();
+    await expect
+      .poll(async () => objectSigningCheckbox.isChecked(), { timeout: 30000 })
+      .toBeTruthy();
+  }
+
   // Activate the release
   await page.getByRole("button", { name: "Activate Release" }).first().click();
 
   // Check that the release is active
   await expect(
-    page.getByText("Data sharing is activated for this release")
+    page.getByText("Data sharing is activated for this release"),
   ).toBeVisible();
 });


### PR DESCRIPTION
Fix #494 

- Bug fixes
- Fix CloudTrailLake query for AccessPoint via the ARN created
- Store AccessPoint ARN in `release::Activation` schema when a cloudformationInstallJob installed finished
- Add some logic when deactivating release
	- Cannot deactivate when running job exist
	- uninstalling access point when release deactivated
- Error when activating a release with no sharing mechanism
- Some UI addition


To consider:
- Select Access Point name should not update Db until it is installed