### PR TITLE
AWS Access Point refinement

### DIFF
--- a/application/backend/src/api/routes/internal-trpc/release/release-job-router.ts
+++ b/application/backend/src/api/routes/internal-trpc/release/release-job-router.ts
@@ -18,6 +18,7 @@ export const releaseJobRouter = router({
   startAwsAccessPointInstall: internalProcedure
     .input(
       z.object({
+        awsAccessPointName: z.string(),
         releaseKey: inputReleaseKey,
       }),
     )
@@ -27,6 +28,7 @@ export const releaseJobRouter = router({
         await ctx.awsAccessPointService.createAccessPointCloudFormationTemplate(
           ctx.user,
           input.releaseKey,
+          input.awsAccessPointName,
         );
 
       // start the job that actually installs the cloud formation

--- a/application/backend/src/business/exceptions/release-configuration.ts
+++ b/application/backend/src/business/exceptions/release-configuration.ts
@@ -1,0 +1,7 @@
+import { Base7807Error } from "@umccr/elsa-types/error-types";
+
+export class ReleaseConfigurationError extends Base7807Error {
+  constructor(errorString?: string) {
+    super("The configuration given is not valid", 400, errorString);
+  }
+}

--- a/application/backend/src/business/services/releases/release-activation-service.ts
+++ b/application/backend/src/business/services/releases/release-activation-service.ts
@@ -230,7 +230,7 @@ export class ReleaseActivationService extends ReleaseBaseService {
 
         {
           // If release is deactivated, all access that was given should be revoked (e.g. AccessPoint)
-          // Mind refactor this out to its own function as things to revoke grows
+          // Might refactor this out to its own function as things to revoke grows
           const isAllowedAwsAccessPointConfig =
             this.configForAwsAccessPointFeature();
 

--- a/application/backend/src/business/services/releases/release-base-service.ts
+++ b/application/backend/src/business/services/releases/release-base-service.ts
@@ -249,6 +249,8 @@ export abstract class ReleaseBaseService {
       };
     } else {
       return {
+        // We need some info (name) about the active AccessPoint to show in FE
+        // This could be possible if this Access Point details is removed from the config
         name:
           isAwsAccessPointInstalled && awsAccessPointName
             ? awsAccessPointName

--- a/application/backend/src/business/services/releases/release-base-service.ts
+++ b/application/backend/src/business/services/releases/release-base-service.ts
@@ -249,7 +249,10 @@ export abstract class ReleaseBaseService {
       };
     } else {
       return {
-        name: "",
+        name:
+          isAwsAccessPointInstalled && awsAccessPointName
+            ? awsAccessPointName
+            : "",
         accountId: "",
         vpcId: "",
         installed: isAwsAccessPointInstalled,

--- a/application/backend/src/business/services/sharers/aws-access-point/aws-access-point-service.ts
+++ b/application/backend/src/business/services/sharers/aws-access-point/aws-access-point-service.ts
@@ -212,6 +212,7 @@ export class AwsAccessPointService {
   public async createAccessPointCloudFormationTemplate(
     user: AuthenticatedUser,
     releaseKey: string,
+    accessPointName: string,
   ): Promise<string> {
     // the AWS guard is switched on as this needs to write out to S3
     await this.awsEnabledService.enabledGuard();
@@ -235,6 +236,14 @@ export class AwsAccessPointService {
     if (userRole !== "Administrator") {
       throw new ReleaseViewError(releaseKey);
     }
+
+    // Store access point name to its own db
+    await this.releaseService.setDataSharingConfigurationField(
+      user,
+      releaseKey,
+      "/dataSharingConfiguration/awsAccessPointName",
+      accessPointName,
+    );
 
     const releaseInfo = await this.releaseService.getBase(releaseKey, userRole);
 

--- a/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
+++ b/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useState } from "react";
 import { UseMutationResult } from "@tanstack/react-query";
 import { ReleaseTypeLocal } from "../../shared-types";
 import { SharerAwsAccessPointType } from "../../../../../../backend/src/config/config-schema-sharer";
@@ -25,6 +25,10 @@ export const AwsAccessPointAccordionContent: React.FC<
   PropsWithChildren<AwsAccessPointAccordionContentProps>
 > = (props) => {
   const utils = trpc.useContext();
+
+  const [accessPointNameInput, setAccessPointNameInput] = useState(
+    props.releaseData?.dataSharingAwsAccessPoint?.name || NONE_DISPLAY,
+  );
 
   const onSuccess = async () => {
     await utils.release.getSpecificRelease.invalidate({
@@ -148,28 +152,9 @@ export const AwsAccessPointAccordionContent: React.FC<
         </label>
         <select
           className="input-bordered input w-full"
-          value={
-            props.releaseData?.dataSharingAwsAccessPoint?.name || NONE_DISPLAY
-          }
+          value={accessPointNameInput}
           onChange={(e) => {
-            // we make sure we are only changing to a name that exists in our config
-            const newName = Object.keys(
-              props.awsAccessPointSetting.allowedVpcs,
-            ).find((name) => name === e.target.value);
-
-            if (newName) {
-              props.releasePatchMutator.mutate({
-                op: "replace",
-                path: "/dataSharingConfiguration/awsAccessPointName",
-                value: newName,
-              });
-            } else {
-              props.releasePatchMutator.mutate({
-                op: "replace",
-                path: "/dataSharingConfiguration/awsAccessPointName",
-                value: "",
-              });
-            }
+            setAccessPointNameInput(e.target.value);
           }}
         >
           <option key="none" value={""} disabled={isVPCOptionDisabled}>
@@ -225,6 +210,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           onClick={() => {
             accessPointInstallTriggerMutate.mutate({
               releaseKey: props.releaseKey,
+              awsAccessPointName: accessPointNameInput,
             });
           }}
           disabled={isInstallDisabled}

--- a/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
+++ b/application/frontend/src/pages/releases/detail/sharer-control-box/aws-access-point-accordion-content.tsx
@@ -32,7 +32,8 @@ export const AwsAccessPointAccordionContent: React.FC<
   const accessPointConfig =
     props.awsAccessPointSetting.allowedVpcs[accessPointNameInput];
 
-  const isApInstalledButConfigRemoved =
+  // There is a possibility that there is an active access point but it is no longer in the configuration
+  const isActiveAccessPointButNoConfig =
     !Object.keys(props.awsAccessPointSetting.allowedVpcs).find(
       (name) => name === accessPointNameInput,
     ) && props.releaseData?.dataSharingAwsAccessPoint?.installed;
@@ -162,7 +163,8 @@ export const AwsAccessPointAccordionContent: React.FC<
             setAccessPointNameInput(e.target.value);
           }}
         >
-          {isApInstalledButConfigRemoved && (
+          {/* We want to show the active access point despite no longer in the option/VPCconfig */}
+          {isActiveAccessPointButNoConfig && (
             <option
               key="installed-but-removed"
               value={accessPointNameInput}
@@ -183,7 +185,7 @@ export const AwsAccessPointAccordionContent: React.FC<
           )}
         </select>
 
-        {isApInstalledButConfigRemoved && (
+        {isActiveAccessPointButNoConfig && (
           <span className="label-text-alt text-slate-400 mt-2">
             {`*This access point is installed but the configuration was removed`}
           </span>


### PR DESCRIPTION
- Access Point name is updated only when user click on install
- Checks before updating Access Point name (Not allowing when there is an active AP and Making sure AP name is align with config)
- AP name still appear if there is an installed AP despite it is removed from the config 